### PR TITLE
Feat: extend Expression operations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-analyzer"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Evgeny Ukhanov <mrlsd@ya.ru>"]
 description = "Semantic analyzer library for compilers written in Rust for semantic analysis of programming languages AST"
 keywords = ["compiler", "semantic-analisis", "semantic-alalyzer", "compiler-design", "semantic"]

--- a/src/semantic.rs
+++ b/src/semantic.rs
@@ -1066,9 +1066,12 @@ impl State {
                     return None;
                 };
                 // Return result as register
+                body_state.borrow_mut().inc_register();
                 ExpressionResult {
                     expr_type: ty,
-                    expr_value: ExpressionResultValue::Register,
+                    expr_value: ExpressionResultValue::Register(
+                        body_state.borrow().last_register_number,
+                    ),
                 }
             }
             // Check is expression primitive value
@@ -1086,9 +1089,12 @@ impl State {
                 // And result of function always stored in register.
                 let func_call_ty = self.function_call(fn_call, body_state)?;
                 // Return result as register
+                body_state.borrow_mut().inc_register();
                 ExpressionResult {
                     expr_type: func_call_ty,
-                    expr_value: ExpressionResultValue::Register,
+                    expr_value: ExpressionResultValue::Register(
+                        body_state.borrow().last_register_number,
+                    ),
                 }
             }
             ast::ExpressionValue::StructValue(value) => {
@@ -1147,9 +1153,12 @@ impl State {
                     .context
                     .expression_struct_value(val.clone(), attributes.clone().attr_index);
 
+                body_state.borrow_mut().inc_register();
                 ExpressionResult {
                     expr_type: attributes.attr_type,
-                    expr_value: ExpressionResultValue::Register,
+                    expr_value: ExpressionResultValue::Register(
+                        body_state.borrow().last_register_number,
+                    ),
                 }
             }
             ast::ExpressionValue::Expression(expr) => {
@@ -1175,9 +1184,12 @@ impl State {
                 right_value.clone(),
             );
             // Expression result value  for Operations is always should be "register"
+            body_state.borrow_mut().inc_register();
             ExpressionResult {
                 expr_type: right_value.expr_type,
-                expr_value: ExpressionResultValue::Register,
+                expr_value: ExpressionResultValue::Register(
+                    body_state.borrow().last_register_number,
+                ),
             }
         } else {
             right_value

--- a/src/semantic.rs
+++ b/src/semantic.rs
@@ -1186,7 +1186,7 @@ impl State {
         // Check is for right value contain next operation
         if let Some((operation, expr)) = &right_expression.operation {
             // Recursively call, where current Execution result set as left
-            // side expression
+            // side expressionf
             self.expression_operation(Some(&expression_result), expr, Some(operation), body_state)
         } else {
             Some(expression_result)
@@ -1235,7 +1235,7 @@ impl State {
                         ast::ExpressionValue::Expression(Box::new(ast::Expression {
                             expression_value: data.expression_value,
                             operation: Some((
-                                op,
+                                op.clone(),
                                 Box::new(ast::Expression {
                                     expression_value: expr.expression_value,
                                     operation: None,
@@ -1252,7 +1252,16 @@ impl State {
                 } else {
                     // If priority not equal for current level just
                     // fetch right side of expression for next branches
-                    let new_expr = Self::fetch_op_priority(*expr, priority_level);
+                    let new_expr =
+                        if next_op.priority() > op.priority() && next_expr.operation.is_none() {
+                            // Pack expression to leaf
+                            ast::Expression {
+                                expression_value: ast::ExpressionValue::Expression(expr),
+                                operation: None,
+                            }
+                        } else {
+                            Self::fetch_op_priority(*expr, priority_level)
+                        };
                     // Rebuild expression tree
                     ast::Expression {
                         expression_value: data.expression_value,

--- a/src/types/expression.rs
+++ b/src/types/expression.rs
@@ -25,7 +25,7 @@ pub struct ExpressionResult {
 #[derive(Debug, Clone, PartialEq)]
 pub enum ExpressionResultValue {
     PrimitiveValue(PrimitiveValue),
-    Register,
+    Register(u64),
 }
 
 /// Expression value kinds:

--- a/tests/expressions_tests.rs
+++ b/tests/expressions_tests.rs
@@ -4,7 +4,7 @@ use semantic_analyzer::ast::{
     CodeLocation, GetLocation, GetName, Ident, MAX_PRIORITY_LEVEL_FOR_EXPRESSIONS,
 };
 use semantic_analyzer::types::expression::{
-    Expression, ExpressionOperations, ExpressionResult, ExpressionStructValue,
+    Expression, ExpressionOperations, ExpressionResult, ExpressionStructValue, ExpressionValue,
 };
 use semantic_analyzer::types::semantic::SemanticStackContext;
 use semantic_analyzer::types::{
@@ -33,6 +33,8 @@ fn expression_ast_transform() {
     let value_name_into: ValueName = value_name.into();
     assert_eq!(value_name_into.to_string(), "x");
     let expr_into: Expression = expr.into();
+    // For grcov
+    println!("{expr_into:?}");
     assert_eq!(expr_into.expression_value.to_string(), "x");
     assert_eq!(expr_into.to_string(), "x");
     let value_name_into2: ValueName = String::from("x1").into();
@@ -670,8 +672,13 @@ fn expression_struct_value() {
         name: ast::ValueName::new(Ident::new("x")),
         attribute: ast::ValueName::new(Ident::new("attr1")),
     };
+    let expression_st_value = ast::ExpressionValue::StructValue(expr_struct_val);
+    let expression_st_value_into: ExpressionValue = expression_st_value.clone().into();
+    assert_eq!(expression_st_value_into.to_string(), "x");
+    // For grcov
+    print!("{expression_st_value_into:?}");
     let expr = ast::Expression {
-        expression_value: ast::ExpressionValue::StructValue(expr_struct_val),
+        expression_value: expression_st_value,
         operation: None,
     };
     let s_attr = ast::StructType {
@@ -728,8 +735,13 @@ fn expression_func_call() {
         name: fn_name.clone(),
         parameters: vec![],
     };
+    let ast_fn_call = ast::ExpressionValue::FunctionCall(fn_call);
+    let expr_value_into: ExpressionValue = ast_fn_call.clone().into();
+    assert_eq!(expr_value_into.to_string(), "fn1");
+    // For grcov
+    println!("{expr_value_into:?}");
     let expr = ast::Expression {
-        expression_value: ast::ExpressionValue::FunctionCall(fn_call),
+        expression_value: ast_fn_call,
         operation: None,
     };
     let res = t.state.expression(&expr, &block_state);
@@ -945,11 +957,18 @@ fn expression_multiple_operation2() {
         expression_value: ast::ExpressionValue::Expression(Box::new(next_expr1)),
         operation: None,
     };
+    // Expr test Into transformation
+    let ast_expr = ast::ExpressionValue::Expression(Box::new(prev_expr.clone()));
+    let ast_expr_into: ExpressionValue = ast_expr.into();
+    assert_eq!(ast_expr_into.to_string(), "2");
     // Expr (100 + 2) * (3 - 4 - 5 * 6)
     let expr = ast::Expression {
         expression_value: ast::ExpressionValue::Expression(Box::new(prev_expr)),
         operation: Some((ast::ExpressionOperations::Multiply, Box::new(next_expr))),
     };
+    let expr_into: Expression = expr.clone().into();
+    // For grcov
+    print!("{expr_into:?}");
     let res = t.state.expression(&expr, &block_state).unwrap();
     assert_eq!(
         res,

--- a/tests/expressions_tests.rs
+++ b/tests/expressions_tests.rs
@@ -361,7 +361,7 @@ fn expression_value_name_exists() {
         .values
         .insert(value_name.into(), value.clone());
     let res = t.state.expression(&expr, &block_state).unwrap();
-    assert_eq!(res.expr_value, ExpressionResultValue::Register);
+    assert_eq!(res.expr_value, ExpressionResultValue::Register(1));
     assert_eq!(res.expr_type, ty);
     let state = block_state.borrow().context.clone().get();
     assert_eq!(state.len(), 1);
@@ -394,7 +394,7 @@ fn expression_const_exists() {
     };
     t.state.global.constants.insert(name, value.clone());
     let res = t.state.expression(&expr, &block_state).unwrap();
-    assert_eq!(res.expr_value, ExpressionResultValue::Register);
+    assert_eq!(res.expr_value, ExpressionResultValue::Register(1));
     assert_eq!(res.expr_type, ty);
     let state = block_state.borrow().context.clone().get();
     assert_eq!(state.len(), 1);
@@ -706,7 +706,7 @@ fn expression_struct_value() {
     assert!(t.is_empty_error());
     let res = t.state.expression(&expr, &block_state).unwrap();
     assert!(t.is_empty_error());
-    assert_eq!(res.expr_value, ExpressionResultValue::Register);
+    assert_eq!(res.expr_value, ExpressionResultValue::Register(1));
     assert_eq!(res.expr_type, Type::Primitive(PrimitiveTypes::Bool));
     let state = block_state.borrow().context.clone().get();
     assert_eq!(state.len(), 1);
@@ -753,7 +753,7 @@ fn expression_func_call() {
     assert_eq!(
         res,
         ExpressionResult {
-            expr_value: ExpressionResultValue::Register,
+            expr_value: ExpressionResultValue::Register(1),
             expr_type: Type::Primitive(PrimitiveTypes::Ptr)
         }
     );
@@ -815,7 +815,7 @@ fn expression_operation() {
         res,
         ExpressionResult {
             expr_type: Type::Primitive(PrimitiveTypes::Char),
-            expr_value: ExpressionResultValue::Register
+            expr_value: ExpressionResultValue::Register(1)
         }
     );
     let state = block_state.borrow().context.clone().get();
@@ -899,7 +899,7 @@ fn expression_multiple_operation1() {
         res,
         ExpressionResult {
             expr_type: Type::Primitive(PrimitiveTypes::U16),
-            expr_value: ExpressionResultValue::Register
+            expr_value: ExpressionResultValue::Register(5)
         }
     );
     // let state = block_state.borrow().context.clone().get();
@@ -955,7 +955,7 @@ fn expression_multiple_operation2() {
         res,
         ExpressionResult {
             expr_type: Type::Primitive(PrimitiveTypes::U16),
-            expr_value: ExpressionResultValue::Register
+            expr_value: ExpressionResultValue::Register(5)
         }
     );
     // let state = block_state.borrow().context.clone().get();

--- a/tests/state_tests.rs
+++ b/tests/state_tests.rs
@@ -12,6 +12,7 @@ use std::rc::Rc;
 #[test]
 fn state_init() {
     let st = State::default();
+    println!("{st:?}");
     assert!(st.global.types.is_empty());
     assert!(st.global.constants.is_empty());
     assert!(st.global.functions.is_empty());
@@ -194,4 +195,28 @@ fn block_state_value() {
     assert_eq!(bst1.borrow().get_value_name(&vn1).unwrap(), val.clone());
     assert_eq!(bst2.borrow().get_value_name(&vn1).unwrap(), val);
     assert!(bst3.borrow().get_value_name(&vn1).is_none());
+
+    assert_eq!(bst1.borrow().last_register_number, 0);
+    assert_eq!(bst2.borrow().last_register_number, 0);
+    bst2.borrow_mut().inc_register();
+    assert_eq!(bst1.borrow().last_register_number, 1);
+    assert_eq!(bst2.borrow().last_register_number, 1);
+}
+
+#[test]
+fn block_state_last_register_inc() {
+    let bst1 = Rc::new(RefCell::new(BlockState::new(None)));
+    let bst2 = Rc::new(RefCell::new(BlockState::new(Some(bst1.clone()))));
+    let mut bst3 = BlockState::new(None);
+
+    assert_eq!(bst1.borrow().last_register_number, 0);
+    assert_eq!(bst2.borrow().last_register_number, 0);
+    bst2.borrow_mut().inc_register();
+    assert_eq!(bst1.borrow().last_register_number, 1);
+    assert_eq!(bst2.borrow().last_register_number, 1);
+
+    assert_eq!(bst3.last_register_number, 0);
+    bst3.inc_register();
+    assert_eq!(bst3.last_register_number, 1);
+    println!("{bst3:?}");
 }

--- a/tests/state_tests.rs
+++ b/tests/state_tests.rs
@@ -12,7 +12,8 @@ use std::rc::Rc;
 #[test]
 fn state_init() {
     let st = State::default();
-    println!("{st:?}");
+    // For grcov
+    format!("{st:?}");
     assert!(st.global.types.is_empty());
     assert!(st.global.constants.is_empty());
     assert!(st.global.functions.is_empty());
@@ -218,5 +219,6 @@ fn block_state_last_register_inc() {
     assert_eq!(bst3.last_register_number, 0);
     bst3.inc_register();
     assert_eq!(bst3.last_register_number, 1);
-    println!("{bst3:?}");
+    // For grcov
+    format!("{bst3:?}");
 }


### PR DESCRIPTION
## Description

Extend Expression operations.

- Fixed fetch priority operations for expressions operations: case when last brench of AST was not packed to Expression leaf to reorgonized expressions priority
- Extended Expressions `SturctValues` attributes analyzing
- Extended Expressions `SturctValues` tests
- Extended Expressions `Operations` tests-many cases for priority expressions check