### PR TITLE
Feat: extend tests for `func-call` and `let-binding`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Run grcov
         run: |
           mkdir ./target/debug/coverage/
-          grcov . -s . -b ./target/debug/ -o ./target/debug/coverage/
+          grcov . -s . -b ./target/debug/ -o ./target/debug/coverage/  --ignore-not-existing --excl-line="grcov-excl-line|#\\[derive\\(|//!|///" --ignore="*.cargo/*" --ignore="src/lib.rs"
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
         env:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-analyzer"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Evgeny Ukhanov <mrlsd@ya.ru>"]
 description = "Semantic analyzer library for compilers written in Rust for semantic analysis of programming languages AST"
 keywords = ["compiler", "semantic-analisis", "semantic-alalyzer", "compiler-design", "semantic"]

--- a/tests/function_call_tests.rs
+++ b/tests/function_call_tests.rs
@@ -1,0 +1,55 @@
+use crate::utils::SemanticTest;
+use semantic_analyzer::ast;
+use semantic_analyzer::ast::{CodeLocation, GetLocation, Ident};
+use semantic_analyzer::types::block_state::BlockState;
+use semantic_analyzer::types::error::StateErrorKind;
+use semantic_analyzer::types::FunctionCall;
+use std::cell::RefCell;
+use std::rc::Rc;
+
+mod utils;
+
+#[test]
+fn func_call_transform() {
+    let fn_name = ast::FunctionName::new(Ident::new("fn1"));
+    let fn_call = ast::FunctionCall {
+        name: fn_name.clone(),
+        parameters: vec![],
+    };
+    let fn_call_into: FunctionCall = fn_call.clone().into();
+    assert_eq!(fn_call.location(), CodeLocation::new(1, 0));
+    assert_eq!(fn_call.name.to_string(), "fn1");
+    assert_eq!(fn_call_into.to_string(), "fn1");
+    assert!(fn_call_into.parameters.is_empty());
+
+    let param1 = ast::Expression {
+        expression_value: ast::ExpressionValue::PrimitiveValue(ast::PrimitiveValue::Ptr),
+        operation: None,
+    };
+    let fn_call2 = ast::FunctionCall {
+        name: fn_name.clone(),
+        parameters: vec![param1.clone()],
+    };
+    let fn_call_into2: FunctionCall = fn_call2.clone().into();
+    assert_eq!(fn_call_into2.parameters.len(), 1);
+    assert_eq!(fn_call_into2.parameters[0], param1.into());
+}
+
+#[test]
+fn func_call_not_declared_func() {
+    let block_state = Rc::new(RefCell::new(BlockState::new(None)));
+    let mut t = SemanticTest::new();
+    let fn_name = ast::FunctionName::new(Ident::new("fn1"));
+    let param1 = ast::Expression {
+        expression_value: ast::ExpressionValue::PrimitiveValue(ast::PrimitiveValue::Ptr),
+        operation: None,
+    };
+    let fn_call = ast::FunctionCall {
+        name: fn_name.clone(),
+        parameters: vec![param1.clone()],
+    };
+    let res = t.state.function_call(&fn_call, &block_state);
+    assert!(res.is_none());
+    assert!(t.check_errors_len(1));
+    assert!(t.check_error(StateErrorKind::FunctionNotFound));
+}

--- a/tests/function_call_tests.rs
+++ b/tests/function_call_tests.rs
@@ -3,6 +3,7 @@ use semantic_analyzer::ast;
 use semantic_analyzer::ast::{CodeLocation, GetLocation, Ident};
 use semantic_analyzer::types::block_state::BlockState;
 use semantic_analyzer::types::error::StateErrorKind;
+use semantic_analyzer::types::types::{PrimitiveTypes, Type};
 use semantic_analyzer::types::FunctionCall;
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -52,4 +53,67 @@ fn func_call_not_declared_func() {
     assert!(res.is_none());
     assert!(t.check_errors_len(1));
     assert!(t.check_error(StateErrorKind::FunctionNotFound));
+}
+
+#[test]
+fn func_call_wrong_type() {
+    let block_state = Rc::new(RefCell::new(BlockState::new(None)));
+    let mut t = SemanticTest::new();
+    let fn_name = ast::FunctionName::new(Ident::new("fn1"));
+    let fn_decl_param1 = ast::FunctionParameter {
+        name: ast::ParameterName::new(Ident::new("x")),
+        parameter_type: ast::Type::Primitive(ast::PrimitiveTypes::Bool),
+    };
+    let fn_statement = ast::FunctionStatement {
+        name: fn_name.clone(),
+        parameters: vec![fn_decl_param1],
+        result_type: ast::Type::Primitive(ast::PrimitiveTypes::I16),
+        body: vec![],
+    };
+    t.state.function_declaration(&fn_statement);
+    assert!(t.is_empty_error());
+
+    let param1 = ast::Expression {
+        expression_value: ast::ExpressionValue::PrimitiveValue(ast::PrimitiveValue::F64(1.2)),
+        operation: None,
+    };
+    let fn_call = ast::FunctionCall {
+        name: fn_name.clone(),
+        parameters: vec![param1.clone()],
+    };
+    let res = t.state.function_call(&fn_call, &block_state).unwrap();
+    assert_eq!(res, Type::Primitive(PrimitiveTypes::I16));
+    assert!(t.check_errors_len(1));
+    assert!(t.check_error(StateErrorKind::FunctionParameterTypeWrong));
+}
+
+#[test]
+fn func_call_declared_func() {
+    let block_state = Rc::new(RefCell::new(BlockState::new(None)));
+    let mut t = SemanticTest::new();
+    let fn_name = ast::FunctionName::new(Ident::new("fn1"));
+    let fn_decl_param1 = ast::FunctionParameter {
+        name: ast::ParameterName::new(Ident::new("x")),
+        parameter_type: ast::Type::Primitive(ast::PrimitiveTypes::Bool),
+    };
+    let fn_statement = ast::FunctionStatement {
+        name: fn_name.clone(),
+        parameters: vec![fn_decl_param1],
+        result_type: ast::Type::Primitive(ast::PrimitiveTypes::I32),
+        body: vec![],
+    };
+    t.state.function_declaration(&fn_statement);
+    assert!(t.is_empty_error());
+
+    let param1 = ast::Expression {
+        expression_value: ast::ExpressionValue::PrimitiveValue(ast::PrimitiveValue::Bool(true)),
+        operation: None,
+    };
+    let fn_call = ast::FunctionCall {
+        name: fn_name.clone(),
+        parameters: vec![param1.clone()],
+    };
+    let res = t.state.function_call(&fn_call, &block_state).unwrap();
+    assert_eq!(res, Type::Primitive(PrimitiveTypes::I32));
+    assert!(t.is_empty_error());
 }

--- a/tests/function_declaration_tests.rs
+++ b/tests/function_declaration_tests.rs
@@ -40,7 +40,7 @@ fn function_declaration_without_body() {
 }
 
 #[test]
-fn function_declaration_wrong_typecd() {
+fn function_declaration_wrong_type() {
     let mut t = SemanticTest::new();
     let fn_name = ast::FunctionName::new(Ident::new("fn2"));
 

--- a/tests/lbinding_tests.rs
+++ b/tests/lbinding_tests.rs
@@ -110,7 +110,7 @@ fn binding_value_not_mutable() {
     );
     let binding = ast::Binding {
         name: ValueName::new(Ident::new("x")),
-        value: Box::new(expr.into()),
+        value: Box::new(expr),
     };
     t.state.binding(&binding, &block_state);
     assert!(t.check_errors_len(1));
@@ -161,7 +161,7 @@ fn binding_value_found() {
     );
     let binding = ast::Binding {
         name: ValueName::new(Ident::new("x")),
-        value: Box::new(expr.into()),
+        value: Box::new(expr),
     };
     t.state.binding(&binding, &block_state);
     assert!(t.is_empty_error());

--- a/tests/lbinding_tests.rs
+++ b/tests/lbinding_tests.rs
@@ -1,9 +1,12 @@
 use crate::utils::SemanticTest;
 use semantic_analyzer::ast;
-use semantic_analyzer::ast::{CodeLocation, GetLocation, GetName, Ident};
+use semantic_analyzer::ast::{CodeLocation, GetLocation, GetName, Ident, ValueName};
 use semantic_analyzer::types::block_state::BlockState;
 use semantic_analyzer::types::error::StateErrorKind;
-use semantic_analyzer::types::Binding;
+use semantic_analyzer::types::expression::{ExpressionResult, ExpressionResultValue};
+use semantic_analyzer::types::semantic::SemanticStackContext;
+use semantic_analyzer::types::types::{PrimitiveTypes, Type};
+use semantic_analyzer::types::{Binding, InnerValueName, PrimitiveValue, Value};
 use std::cell::RefCell;
 use std::rc::Rc;
 
@@ -64,7 +67,102 @@ fn binding_value_not_exist() {
 }
 
 #[test]
-fn binding_value_not_mutable() {}
+fn binding_value_not_mutable() {
+    let block_state = Rc::new(RefCell::new(BlockState::new(None)));
+    let mut t = SemanticTest::new();
+    let expr = ast::Expression {
+        expression_value: ast::ExpressionValue::PrimitiveValue(ast::PrimitiveValue::U64(30)),
+        operation: None,
+    };
+    let let_binding = ast::LetBinding {
+        name: ast::ValueName::new(Ident::new("x")),
+        mutable: false,
+        value_type: Some(ast::Type::Primitive(ast::PrimitiveTypes::U64)),
+        value: Box::new(expr.clone()),
+    };
+    t.state.let_binding(&let_binding, &block_state);
+    assert!(t.is_empty_error());
+    let inner_name: InnerValueName = "x.0".into();
+    let val = Value {
+        inner_name: inner_name.clone(),
+        inner_type: Type::Primitive(PrimitiveTypes::U64),
+        mutable: false,
+        alloca: false,
+        malloc: false,
+    };
+
+    let state = block_state.borrow().context.clone().get();
+    assert_eq!(state.len(), 1);
+    assert_eq!(
+        state[0],
+        SemanticStackContext::LetBinding {
+            let_decl: val.clone(),
+            expr_result: ExpressionResult {
+                expr_type: Type::Primitive(PrimitiveTypes::U64),
+                expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::U64(30))
+            },
+        }
+    );
+    assert!(block_state.borrow().inner_values_name.contains(&inner_name));
+    assert_eq!(
+        block_state.borrow().values.get(&("x".into())).unwrap(),
+        &val
+    );
+    let binding = ast::Binding {
+        name: ValueName::new(Ident::new("x")),
+        value: Box::new(expr.into()),
+    };
+    t.state.binding(&binding, &block_state);
+    assert!(t.check_errors_len(1));
+    assert!(t.check_error(StateErrorKind::ValueIsNotMutable));
+}
 
 #[test]
-fn binding_value_found() {}
+fn binding_value_found() {
+    let block_state = Rc::new(RefCell::new(BlockState::new(None)));
+    let mut t = SemanticTest::new();
+    let expr = ast::Expression {
+        expression_value: ast::ExpressionValue::PrimitiveValue(ast::PrimitiveValue::U64(30)),
+        operation: None,
+    };
+    let let_binding = ast::LetBinding {
+        name: ast::ValueName::new(Ident::new("x")),
+        mutable: true,
+        value_type: Some(ast::Type::Primitive(ast::PrimitiveTypes::U64)),
+        value: Box::new(expr.clone()),
+    };
+    t.state.let_binding(&let_binding, &block_state);
+    assert!(t.is_empty_error());
+    let inner_name: InnerValueName = "x.0".into();
+    let val = Value {
+        inner_name: inner_name.clone(),
+        inner_type: Type::Primitive(PrimitiveTypes::U64),
+        mutable: true,
+        alloca: false,
+        malloc: false,
+    };
+
+    let state = block_state.borrow().context.clone().get();
+    assert_eq!(state.len(), 1);
+    assert_eq!(
+        state[0],
+        SemanticStackContext::LetBinding {
+            let_decl: val.clone(),
+            expr_result: ExpressionResult {
+                expr_type: Type::Primitive(PrimitiveTypes::U64),
+                expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::U64(30))
+            },
+        }
+    );
+    assert!(block_state.borrow().inner_values_name.contains(&inner_name));
+    assert_eq!(
+        block_state.borrow().values.get(&("x".into())).unwrap(),
+        &val
+    );
+    let binding = ast::Binding {
+        name: ValueName::new(Ident::new("x")),
+        value: Box::new(expr.into()),
+    };
+    t.state.binding(&binding, &block_state);
+    assert!(t.is_empty_error());
+}

--- a/tests/lbinding_tests.rs
+++ b/tests/lbinding_tests.rs
@@ -1,0 +1,70 @@
+use crate::utils::SemanticTest;
+use semantic_analyzer::ast;
+use semantic_analyzer::ast::{CodeLocation, GetLocation, GetName, Ident};
+use semantic_analyzer::types::block_state::BlockState;
+use semantic_analyzer::types::error::StateErrorKind;
+use semantic_analyzer::types::Binding;
+use std::cell::RefCell;
+use std::rc::Rc;
+
+mod utils;
+
+#[test]
+fn binding_transform() {
+    let expr_ast = ast::Expression {
+        expression_value: ast::ExpressionValue::PrimitiveValue(ast::PrimitiveValue::U64(3)),
+        operation: None,
+    };
+    let binding_ast = ast::Binding {
+        name: ast::ValueName::new(Ident::new("x")),
+        value: Box::new(expr_ast.clone()),
+    };
+    assert_eq!(binding_ast.location(), CodeLocation::new(1, 0));
+    assert_eq!(binding_ast.clone().name(), "x");
+
+    let binding: Binding = binding_ast.clone().into();
+    assert_eq!(binding.clone().to_string(), "x");
+    assert_eq!(binding.value, Box::new(expr_ast.into()));
+    // For grcov
+    format!("{:?}", binding_ast.clone());
+}
+
+#[test]
+fn binding_wrong_expression() {
+    let block_state = Rc::new(RefCell::new(BlockState::new(None)));
+    let mut t = SemanticTest::new();
+    let expr = ast::Expression {
+        expression_value: ast::ExpressionValue::ValueName(ast::ValueName::new(Ident::new("x"))),
+        operation: None,
+    };
+    let binding = ast::Binding {
+        name: ast::ValueName::new(Ident::new("x")),
+        value: Box::new(expr),
+    };
+    t.state.binding(&binding, &block_state);
+    assert!(t.check_errors_len(1));
+    assert!(t.check_error(StateErrorKind::ValueNotFound));
+}
+
+#[test]
+fn binding_value_not_exist() {
+    let block_state = Rc::new(RefCell::new(BlockState::new(None)));
+    let mut t = SemanticTest::new();
+    let expr = ast::Expression {
+        expression_value: ast::ExpressionValue::PrimitiveValue(ast::PrimitiveValue::I16(23)),
+        operation: None,
+    };
+    let binding = ast::Binding {
+        name: ast::ValueName::new(Ident::new("x")),
+        value: Box::new(expr),
+    };
+    t.state.binding(&binding, &block_state);
+    assert!(t.check_errors_len(1));
+    assert!(t.check_error(StateErrorKind::ValueNotFound));
+}
+
+#[test]
+fn binding_value_not_mutable() {}
+
+#[test]
+fn binding_value_found() {}

--- a/tests/let_binding_tests.rs
+++ b/tests/let_binding_tests.rs
@@ -1,0 +1,82 @@
+use crate::utils::SemanticTest;
+use semantic_analyzer::ast;
+use semantic_analyzer::ast::{CodeLocation, GetLocation, GetName, Ident};
+use semantic_analyzer::types::block_state::BlockState;
+use semantic_analyzer::types::error::StateErrorKind;
+use semantic_analyzer::types::types::{PrimitiveTypes, Type};
+use semantic_analyzer::types::LetBinding;
+use std::cell::RefCell;
+use std::rc::Rc;
+
+mod utils;
+
+#[test]
+fn let_binding_transform() {
+    let expr_ast = ast::Expression {
+        expression_value: ast::ExpressionValue::PrimitiveValue(ast::PrimitiveValue::U64(3)),
+        operation: None,
+    };
+    let let_binding_ast = ast::LetBinding {
+        name: ast::ValueName::new(Ident::new("x")),
+        mutable: true,
+        value_type: Some(ast::Type::Primitive(ast::PrimitiveTypes::U64)),
+        value: Box::new(expr_ast.clone()),
+    };
+    assert_eq!(let_binding_ast.location(), CodeLocation::new(1, 0));
+    assert_eq!(let_binding_ast.clone().name(), "x");
+
+    let let_binding: LetBinding = let_binding_ast.clone().into();
+    assert_eq!(let_binding.clone().to_string(), "x");
+    assert!(let_binding.mutable);
+    assert_eq!(
+        let_binding.value_type,
+        Some(Type::Primitive(PrimitiveTypes::U64))
+    );
+    assert_eq!(let_binding.value, Box::new(expr_ast.into()));
+    // For grcov
+    format!("{:?}", let_binding_ast.clone());
+}
+
+#[test]
+fn let_binding_wrong_expression() {
+    let block_state = Rc::new(RefCell::new(BlockState::new(None)));
+    let mut t = SemanticTest::new();
+    let expr = ast::Expression {
+        expression_value: ast::ExpressionValue::ValueName(ast::ValueName::new(Ident::new("x"))),
+        operation: None,
+    };
+    let let_binding = ast::LetBinding {
+        name: ast::ValueName::new(Ident::new("x")),
+        mutable: true,
+        value_type: Some(ast::Type::Primitive(ast::PrimitiveTypes::U64)),
+        value: Box::new(expr),
+    };
+    t.state.let_binding(&let_binding, &block_state);
+    assert!(t.check_errors_len(1));
+    assert!(t.check_error(StateErrorKind::ValueNotFound));
+}
+
+#[test]
+fn let_binding_wrong_type() {
+    let block_state = Rc::new(RefCell::new(BlockState::new(None)));
+    let mut t = SemanticTest::new();
+    let expr = ast::Expression {
+        expression_value: ast::ExpressionValue::PrimitiveValue(ast::PrimitiveValue::Bool(true)),
+        operation: None,
+    };
+    let let_binding = ast::LetBinding {
+        name: ast::ValueName::new(Ident::new("x")),
+        mutable: true,
+        value_type: Some(ast::Type::Primitive(ast::PrimitiveTypes::U64)),
+        value: Box::new(expr),
+    };
+    t.state.let_binding(&let_binding, &block_state);
+    assert!(t.check_errors_len(1));
+    assert!(t.check_error(StateErrorKind::WrongLetType));
+}
+
+#[test]
+fn let_binding_value_not_found() {}
+
+#[test]
+fn let_binding_value_found() {}

--- a/tests/let_binding_tests.rs
+++ b/tests/let_binding_tests.rs
@@ -3,8 +3,10 @@ use semantic_analyzer::ast;
 use semantic_analyzer::ast::{CodeLocation, GetLocation, GetName, Ident};
 use semantic_analyzer::types::block_state::BlockState;
 use semantic_analyzer::types::error::StateErrorKind;
+use semantic_analyzer::types::expression::{ExpressionResult, ExpressionResultValue};
+use semantic_analyzer::types::semantic::SemanticStackContext;
 use semantic_analyzer::types::types::{PrimitiveTypes, Type};
-use semantic_analyzer::types::LetBinding;
+use semantic_analyzer::types::{InnerValueName, LetBinding, PrimitiveValue, Value};
 use std::cell::RefCell;
 use std::rc::Rc;
 
@@ -76,7 +78,99 @@ fn let_binding_wrong_type() {
 }
 
 #[test]
-fn let_binding_value_not_found() {}
+fn let_binding_value_not_found() {
+    let block_state = Rc::new(RefCell::new(BlockState::new(None)));
+    let mut t = SemanticTest::new();
+    let expr = ast::Expression {
+        expression_value: ast::ExpressionValue::PrimitiveValue(ast::PrimitiveValue::U64(30)),
+        operation: None,
+    };
+    let let_binding = ast::LetBinding {
+        name: ast::ValueName::new(Ident::new("x")),
+        mutable: true,
+        value_type: Some(ast::Type::Primitive(ast::PrimitiveTypes::U64)),
+        value: Box::new(expr),
+    };
+    t.state.let_binding(&let_binding, &block_state);
+    assert!(t.is_empty_error());
+    let state = block_state.borrow().context.clone().get();
+    assert_eq!(state.len(), 1);
+    let inner_name: InnerValueName = "x.0".into();
+    let val = Value {
+        inner_name: inner_name.clone(),
+        inner_type: Type::Primitive(PrimitiveTypes::U64),
+        mutable: true,
+        alloca: false,
+        malloc: false,
+    };
+    assert_eq!(
+        state[0],
+        SemanticStackContext::LetBinding {
+            let_decl: val.clone(),
+            expr_result: ExpressionResult {
+                expr_type: Type::Primitive(PrimitiveTypes::U64),
+                expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::U64(30)),
+            },
+        }
+    );
+    assert!(block_state.borrow().inner_values_name.contains(&inner_name));
+    assert_eq!(
+        block_state.borrow().values.get(&("x".into())).unwrap(),
+        &val
+    );
+}
 
 #[test]
-fn let_binding_value_found() {}
+fn let_binding_value_found() {
+    let block_state = Rc::new(RefCell::new(BlockState::new(None)));
+    let mut t = SemanticTest::new();
+    let expr = ast::Expression {
+        expression_value: ast::ExpressionValue::PrimitiveValue(ast::PrimitiveValue::U64(30)),
+        operation: None,
+    };
+    let inner_name: InnerValueName = "x.0".into();
+    let val = Value {
+        inner_name: inner_name.clone(),
+        inner_type: Type::Primitive(PrimitiveTypes::U64),
+        mutable: true,
+        alloca: false,
+        malloc: false,
+    };
+    block_state
+        .borrow_mut()
+        .values
+        .insert("x".into(), val.clone());
+    let let_binding = ast::LetBinding {
+        name: ast::ValueName::new(Ident::new("x")),
+        mutable: true,
+        value_type: Some(ast::Type::Primitive(ast::PrimitiveTypes::U64)),
+        value: Box::new(expr),
+    };
+    t.state.let_binding(&let_binding, &block_state);
+    assert!(t.is_empty_error());
+    let state = block_state.borrow().context.clone().get();
+    assert_eq!(state.len(), 1);
+
+    let val2 = Value {
+        inner_name: "x.1".into(),
+        ..val.clone()
+    };
+    assert_eq!(
+        state[0],
+        SemanticStackContext::LetBinding {
+            let_decl: val2.clone(),
+            expr_result: ExpressionResult {
+                expr_type: Type::Primitive(PrimitiveTypes::U64),
+                expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::U64(30)),
+            },
+        }
+    );
+    assert!(block_state
+        .borrow()
+        .inner_values_name
+        .contains(&val2.inner_name));
+    assert_eq!(
+        block_state.borrow().values.get(&("x".into())).unwrap(),
+        &val2
+    );
+}


### PR DESCRIPTION
## Description

Added tests and increased tests coverage :arrow_up:. Significantly improved  Github CI :robot:.

- :ballot_box_with_check:  Extended tests for `function-declaration`
- :ballot_box_with_check:  Extended tests for `function-call`
- :ballot_box_with_check: Extended tests for `let-binding`
- :ballot_box_with_check: Extended tests for `binding`
- :ballot_box_with_check: Extended CI
