### PR TITLE
Feat: fix multiple return issue and extend analyzer tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-analyzer"
-version = "0.2.3"
+version = "0.2.4"
 authors = ["Evgeny Ukhanov <mrlsd@ya.ru>"]
 description = "Semantic analyzer library for compilers written in Rust for semantic analysis of programming languages AST"
 keywords = ["compiler", "semantic-analisis", "semantic-alalyzer", "compiler-design", "semantic"]

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -642,7 +642,8 @@ pub struct IfStatement<'a> {
 
 impl GetLocation for IfStatement<'_> {
     fn location(&self) -> CodeLocation {
-        todo!()
+        // TODO
+        CodeLocation::new(1, 0)
     }
 }
 

--- a/src/semantic.rs
+++ b/src/semantic.rs
@@ -1013,6 +1013,12 @@ impl State {
             }
         }
 
+        // Because it's loop jump to loop begin
+        loop_body_state
+            .borrow_mut()
+            .context
+            .jump_to(label_loop_begin.clone());
+
         // Loop ending
         loop_body_state
             .borrow_mut()

--- a/src/semantic.rs
+++ b/src/semantic.rs
@@ -309,8 +309,16 @@ impl State {
                 ast::BodyStatement::Expression(expression)
                 | ast::BodyStatement::Return(expression) => {
                     let expr_result = self.expression(expression, &body_state);
+                    let expr: Expression = expression.clone().into();
+                    // Check is return statement previously called
+                    if return_is_called {
+                        self.add_error(error::StateErrorResult::new(
+                            error::StateErrorKind::ReturnAlreadyCalled,
+                            expr.to_string(),
+                            expression.location(),
+                        ));
+                    }
                     if let Some(res) = expr_result {
-                        let expr: Expression = expression.clone().into();
                         // Check expression type and do not exist from flow
                         self.check_type_exists(&res.expr_type, &expr, &expression.clone());
                         let fn_ty: Type = data.result_type.clone().into();

--- a/src/semantic.rs
+++ b/src/semantic.rs
@@ -775,7 +775,7 @@ impl State {
         label_loop: Option<(&LabelName, &LabelName)>,
     ) {
         // It can't contain `else` and `if-else` on the same time
-        if data.else_if_statement.is_some() && data.else_if_statement.is_some() {
+        if data.else_statement.is_some() && data.else_if_statement.is_some() {
             let stm = data.else_if_statement.clone().unwrap();
             self.add_error(error::StateErrorResult::new(
                 error::StateErrorKind::IfElseDuplicated,
@@ -808,7 +808,7 @@ impl State {
             },
             |label| label,
         );
-        let is_else = data.else_if_statement.is_some() || data.else_if_statement.is_some();
+        let is_else = data.else_statement.is_some() || data.else_if_statement.is_some();
 
         // Analyse if-conditions
         self.if_condition_calculation(

--- a/src/semantic.rs
+++ b/src/semantic.rs
@@ -474,7 +474,7 @@ impl State {
             ));
             return;
         }
-
+        println!("###");
         function_state
             .borrow_mut()
             .context
@@ -792,7 +792,6 @@ impl State {
         function_body_state
             .borrow_mut()
             .set_child(if_body_state.clone());
-
         // Get labels name for if-begin, and if-end
         let label_if_begin = if_body_state
             .borrow_mut()
@@ -805,7 +804,7 @@ impl State {
             || {
                 if_body_state
                     .borrow_mut()
-                    .get_and_set_next_label(&"if_begin".to_string().into())
+                    .get_and_set_next_label(&"if_end".to_string().into())
             },
             |label| label,
         );

--- a/src/semantic.rs
+++ b/src/semantic.rs
@@ -474,7 +474,6 @@ impl State {
             ));
             return;
         }
-        println!("###");
         function_state
             .borrow_mut()
             .context
@@ -783,7 +782,6 @@ impl State {
         label_end: Option<LabelName>,
         label_loop: Option<(&LabelName, &LabelName)>,
     ) {
-        println!("  ->{label_loop:#?}");
         // It can't contain `else` and `if-else` on the same time
         if data.else_statement.is_some() && data.else_if_statement.is_some() {
             let stm = data.else_if_statement.clone().unwrap();

--- a/src/semantic.rs
+++ b/src/semantic.rs
@@ -238,7 +238,7 @@ impl State {
         self.global.context.constant(const_val);
     }
 
-    /// Function declaration analyze. Add it to Global State/
+    /// Function declaration analyze. Add it to Global State/M
     pub fn function_declaration(&mut self, data: &ast::FunctionStatement<'_>) {
         if self.global.functions.contains_key(&data.name().into()) {
             self.add_error(error::StateErrorResult::new(
@@ -774,6 +774,7 @@ impl State {
         label_end: Option<LabelName>,
         label_loop: Option<(&LabelName, &LabelName)>,
     ) {
+        println!("  ->{label_loop:#?}");
         // It can't contain `else` and `if-else` on the same time
         if data.else_statement.is_some() && data.else_if_statement.is_some() {
             let stm = data.else_if_statement.clone().unwrap();
@@ -827,12 +828,21 @@ impl State {
         match &data.body {
             ast::IfBodyStatements::If(body) => {
                 // Analyze if-statement body
-                self.if_condition_body(body, &if_body_state);
+                self.if_condition_body(body, &if_body_state, label_if_end, label_loop);
             }
             ast::IfBodyStatements::Loop(body) => {
-                let (label_loop_start, label_loop_end) = label_loop.expect("label should be set");
+                // It's special case for the Loop, when `label_loop` should always be set.
+                // If it doesn't set, it's unexpected behavior and program algorithm error
+                let (label_loop_start, label_loop_end) =
+                    label_loop.expect("loop label should be set");
                 // Analyze if-loop-statement body
-                self.if_condition_loop_body(body, &if_body_state, label_loop_start, label_loop_end);
+                self.if_condition_loop_body(
+                    body,
+                    &if_body_state,
+                    label_if_end,
+                    label_loop_start,
+                    label_loop_end,
+                );
             }
         }
         // Codegen for jump to if-end statement - return to program flow

--- a/src/semantic.rs
+++ b/src/semantic.rs
@@ -835,7 +835,7 @@ impl State {
                 self.if_condition_loop_body(body, &if_body_state, label_loop_start, label_loop_end);
             }
         }
-        // Codegen for jump to if-end statement -return to program flow
+        // Codegen for jump to if-end statement - return to program flow
         if_body_state
             .borrow_mut()
             .context

--- a/src/types/block_state.rs
+++ b/src/types/block_state.rs
@@ -34,7 +34,6 @@ pub struct BlockState {
     pub labels: HashSet<LabelName>,
     /// Last register for unique register representation
     pub last_register_number: u64,
-
     /// Manual return from other states
     pub manual_return: bool,
     /// Parent state

--- a/src/types/error.rs
+++ b/src/types/error.rs
@@ -21,6 +21,7 @@ pub enum StateErrorKind {
     FunctionNotFound,
     FunctionParameterTypeWrong,
     ReturnNotFound,
+    ReturnAlreadyCalled,
     IfElseDuplicated,
     TypeNotFound,
     WrongReturnType,

--- a/src/types/semantic.rs
+++ b/src/types/semantic.rs
@@ -93,7 +93,7 @@ impl SemanticStack {
 
     /// Push Context to the stack as expression function return data
     pub fn expression_function_return(&mut self, expr_result: ExpressionResult) {
-        self.push(SemanticStackContext::ExpressionFunctionReturnWithLabel { expr_result });
+        self.push(SemanticStackContext::ExpressionFunctionReturn { expr_result });
     }
 
     /// Push Context to the stack as `expression function return with label` data

--- a/tests/binding_tests.rs
+++ b/tests/binding_tests.rs
@@ -110,7 +110,7 @@ fn binding_value_not_mutable() {
     );
     let binding = ast::Binding {
         name: ValueName::new(Ident::new("x")),
-        value: Box::new(expr.into()),
+        value: Box::new(expr),
     };
     t.state.binding(&binding, &block_state);
     assert!(t.check_errors_len(1));
@@ -161,7 +161,7 @@ fn binding_value_found() {
     );
     let binding = ast::Binding {
         name: ValueName::new(Ident::new("x")),
-        value: Box::new(expr.into()),
+        value: Box::new(expr),
     };
     t.state.binding(&binding, &block_state);
     assert!(t.is_empty_error());

--- a/tests/binding_tests.rs
+++ b/tests/binding_tests.rs
@@ -159,10 +159,36 @@ fn binding_value_found() {
         block_state.borrow().values.get(&("x".into())).unwrap(),
         &val
     );
+    let new_expr = ast::Expression {
+        expression_value: ast::ExpressionValue::PrimitiveValue(ast::PrimitiveValue::U64(100)),
+        operation: None,
+    };
     let binding = ast::Binding {
         name: ValueName::new(Ident::new("x")),
-        value: Box::new(expr),
+        value: Box::new(new_expr),
     };
     t.state.binding(&binding, &block_state);
     assert!(t.is_empty_error());
+    let state = block_state.borrow().context.clone().get();
+    assert_eq!(state.len(), 2);
+    assert_eq!(
+        state[0],
+        SemanticStackContext::LetBinding {
+            let_decl: val.clone(),
+            expr_result: ExpressionResult {
+                expr_type: Type::Primitive(PrimitiveTypes::U64),
+                expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::U64(30))
+            },
+        }
+    );
+    assert_eq!(
+        state[1],
+        SemanticStackContext::Binding {
+            val: val.clone(),
+            expr_result: ExpressionResult {
+                expr_type: Type::Primitive(PrimitiveTypes::U64),
+                expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::U64(100))
+            },
+        }
+    );
 }

--- a/tests/function_call_tests.rs
+++ b/tests/function_call_tests.rs
@@ -1,6 +1,6 @@
 use crate::utils::SemanticTest;
 use semantic_analyzer::ast;
-use semantic_analyzer::ast::{CodeLocation, GetLocation, Ident};
+use semantic_analyzer::ast::{CodeLocation, GetLocation, GetName, Ident};
 use semantic_analyzer::types::block_state::BlockState;
 use semantic_analyzer::types::error::StateErrorKind;
 use semantic_analyzer::types::types::{PrimitiveTypes, Type};
@@ -19,6 +19,7 @@ fn func_call_transform() {
     };
     let fn_call_into: FunctionCall = fn_call.clone().into();
     assert_eq!(fn_call.location(), CodeLocation::new(1, 0));
+    assert_eq!(fn_call.name(), "fn1");
     assert_eq!(fn_call.name.to_string(), "fn1");
     assert_eq!(fn_call_into.to_string(), "fn1");
     assert!(fn_call_into.parameters.is_empty());

--- a/tests/if_tests.rs
+++ b/tests/if_tests.rs
@@ -1,0 +1,44 @@
+use semantic_analyzer::ast;
+use semantic_analyzer::ast::Ident;
+use semantic_analyzer::types::condition::{
+    IfBodyStatement, IfBodyStatements, IfCondition, IfStatement,
+};
+
+mod utils;
+
+#[test]
+fn if_transform() {
+    let if_condition_expr = ast::Expression {
+        expression_value: ast::ExpressionValue::PrimitiveValue(ast::PrimitiveValue::F32(1.2)),
+        operation: None,
+    };
+    let if_condition = ast::IfCondition::Single(if_condition_expr.clone());
+    let let_binding = ast::LetBinding {
+        name: ast::ValueName::new(Ident::new("x")),
+        mutable: false,
+        value_type: None,
+        value: Box::new(ast::Expression {
+            expression_value: ast::ExpressionValue::PrimitiveValue(ast::PrimitiveValue::Bool(true)),
+            operation: None,
+        }),
+    };
+    let if_body =
+        ast::IfBodyStatements::If(vec![ast::IfBodyStatement::LetBinding(let_binding.clone())]);
+    let if_statement1 = ast::IfStatement {
+        condition: if_condition.clone(),
+        body: if_body,
+        else_statement: None,
+        else_if_statement: None,
+    };
+    let if_statement1_into: IfStatement = if_statement1.into();
+    assert_eq!(
+        if_statement1_into.condition,
+        IfCondition::Single(if_condition_expr.into())
+    );
+    assert_eq!(
+        if_statement1_into.body,
+        IfBodyStatements::If(vec![IfBodyStatement::LetBinding(let_binding.into())])
+    );
+    assert!(if_statement1_into.else_statement.is_none());
+    assert!(if_statement1_into.else_if_statement.is_none());
+}

--- a/tests/if_tests.rs
+++ b/tests/if_tests.rs
@@ -1,14 +1,3 @@
-/// if_condition:
-/// - if-body: ast:IfBodyStatements::Loop
-///   - ast::IfLoopBodyStatement::LetBinding
-///   - ast::IfLoopBodyStatement::Binding
-///   - ast::IfLoopBodyStatement::FunctionCall
-///   - ast::IfLoopBodyStatement::If
-///   - ast::IfLoopBodyStatement::Loop
-///   - ast::IfLoopBodyStatement::Return
-///     - expr_result.some()
-///   - ast::IfLoopBodyStatement::Continue
-///   - ast::IfLoopBodyStatement::Break
 use crate::utils::SemanticTest;
 use semantic_analyzer::ast;
 use semantic_analyzer::ast::{CodeLocation, GetLocation, Ident};

--- a/tests/if_tests.rs
+++ b/tests/if_tests.rs
@@ -1,10 +1,4 @@
 /// if_condition:
-/// - ast::IfBodyStatement::LetBinding
-/// - ast::IfBodyStatement::Binding
-/// - ast::IfBodyStatement::FunctionCall
-/// - ast::IfBodyStatement::If
-/// - ast::IfBodyStatement::Loop
-/// - ast::IfBodyStatement::Return
 /// - if-body: ast:IfBodyStatements::Loop
 ///   - ast::IfLoopBodyStatement::LetBinding
 ///   - ast::IfLoopBodyStatement::Binding
@@ -15,8 +9,6 @@
 ///     - expr_result.some()
 ///   - ast::IfLoopBodyStatement::Continue
 ///   - ast::IfLoopBodyStatement::Break
-/// - else-body: ast:IfBodyStatements::Loop
-/// - add: else_if_statement
 use crate::utils::SemanticTest;
 use semantic_analyzer::ast;
 use semantic_analyzer::ast::{CodeLocation, GetLocation, Ident};
@@ -792,6 +784,104 @@ fn if_body_statements() {
             if_body_fn_call,
             if_body_if,
             if_body_loop,
+            if_body_return,
+        ]),
+        else_statement: None,
+        else_if_statement: None,
+    };
+
+    t.state.if_condition(
+        &if_stmt,
+        &block_state,
+        None,
+        Some((&label_loop_begin, &label_loop_end)),
+    );
+    // println!("{:#?}", t.state);
+    assert!(t.is_empty_error());
+}
+
+#[test]
+fn if_loop_body_statements() {
+    let block_state = Rc::new(RefCell::new(BlockState::new(None)));
+    let mut t = SemanticTest::new();
+    let if_expr = ast::Expression {
+        expression_value: ast::ExpressionValue::PrimitiveValue(ast::PrimitiveValue::U64(1)),
+        operation: None,
+    };
+
+    let fn2 = ast::FunctionStatement {
+        name: ast::FunctionName::new(Ident::new("fn2")),
+        parameters: vec![],
+        result_type: ast::Type::Primitive(ast::PrimitiveTypes::U16),
+        body: vec![ast::BodyStatement::Expression(ast::Expression {
+            expression_value: ast::ExpressionValue::PrimitiveValue(ast::PrimitiveValue::U16(23)),
+            operation: None,
+        })],
+    };
+    t.state.function_declaration(&fn2);
+
+    let if_body_let_binding = ast::IfLoopBodyStatement::LetBinding(ast::LetBinding {
+        name: ast::ValueName::new(Ident::new("x")),
+        mutable: true,
+        value_type: None,
+        value: Box::new(ast::Expression {
+            expression_value: ast::ExpressionValue::PrimitiveValue(ast::PrimitiveValue::Bool(
+                false,
+            )),
+            operation: None,
+        }),
+    });
+    let if_body_binding = ast::IfLoopBodyStatement::Binding(ast::Binding {
+        name: ast::ValueName::new(Ident::new("x")),
+        value: Box::new(ast::Expression {
+            expression_value: ast::ExpressionValue::PrimitiveValue(ast::PrimitiveValue::Bool(true)),
+            operation: None,
+        }),
+    });
+    let if_body_fn_call = ast::IfLoopBodyStatement::FunctionCall(ast::FunctionCall {
+        name: ast::FunctionName::new(Ident::new("fn2")),
+        parameters: vec![],
+    });
+    let if_body_if = ast::IfLoopBodyStatement::If(ast::IfStatement {
+        condition: ast::IfCondition::Single(ast::Expression {
+            expression_value: ast::ExpressionValue::PrimitiveValue(ast::PrimitiveValue::Bool(true)),
+            operation: None,
+        }),
+        body: ast::IfBodyStatements::Loop(vec![ast::IfLoopBodyStatement::FunctionCall(
+            ast::FunctionCall {
+                name: ast::FunctionName::new(Ident::new("fn2")),
+                parameters: vec![],
+            },
+        )]),
+        else_statement: None,
+        else_if_statement: None,
+    });
+    let if_body_loop = ast::IfLoopBodyStatement::Loop(vec![ast::LoopBodyStatement::FunctionCall(
+        ast::FunctionCall {
+            name: ast::FunctionName::new(Ident::new("fn2")),
+            parameters: vec![],
+        },
+    )]);
+    let if_body_return = ast::IfLoopBodyStatement::Return(ast::Expression {
+        expression_value: ast::ExpressionValue::PrimitiveValue(ast::PrimitiveValue::Bool(true)),
+        operation: None,
+    });
+    let if_body_break = ast::IfLoopBodyStatement::Break;
+    let if_body_continue = ast::IfLoopBodyStatement::Continue;
+
+    let label_loop_begin: LabelName = String::from("loop_begin").into();
+    let label_loop_end: LabelName = String::from("loop_end").into();
+
+    let if_stmt = ast::IfStatement {
+        condition: ast::IfCondition::Single(if_expr),
+        body: ast::IfBodyStatements::Loop(vec![
+            if_body_let_binding,
+            if_body_binding,
+            if_body_fn_call,
+            if_body_if,
+            if_body_loop,
+            if_body_break,
+            if_body_continue,
             if_body_return,
         ]),
         else_statement: None,

--- a/tests/if_tests.rs
+++ b/tests/if_tests.rs
@@ -1,13 +1,15 @@
 use semantic_analyzer::ast;
-use semantic_analyzer::ast::Ident;
+use semantic_analyzer::ast::{CodeLocation, GetLocation, Ident};
 use semantic_analyzer::types::condition::{
-    IfBodyStatement, IfBodyStatements, IfCondition, IfStatement,
+    Condition, ExpressionCondition, ExpressionLogicCondition, IfBodyStatement, IfBodyStatements,
+    IfCondition, IfLoopBodyStatement, IfStatement, LogicCondition,
 };
+use semantic_analyzer::types::expression::Expression;
 
 mod utils;
 
 #[test]
-fn if_transform() {
+fn if_single_transform() {
     let if_condition_expr = ast::Expression {
         expression_value: ast::ExpressionValue::PrimitiveValue(ast::PrimitiveValue::F32(1.2)),
         operation: None,
@@ -22,23 +24,254 @@ fn if_transform() {
             operation: None,
         }),
     };
-    let if_body =
-        ast::IfBodyStatements::If(vec![ast::IfBodyStatement::LetBinding(let_binding.clone())]);
-    let if_statement1 = ast::IfStatement {
+    let binding = ast::Binding {
+        name: ast::ValueName::new(Ident::new("x")),
+        value: Box::new(ast::Expression {
+            expression_value: ast::ExpressionValue::PrimitiveValue(ast::PrimitiveValue::Bool(true)),
+            operation: None,
+        }),
+    };
+    let fn_call = ast::FunctionCall {
+        name: ast::FunctionName::new(Ident::new("fn1")),
+        parameters: vec![],
+    };
+    let if_statement2 = ast::IfStatement {
         condition: if_condition.clone(),
-        body: if_body,
+        body: ast::IfBodyStatements::If(vec![]),
         else_statement: None,
         else_if_statement: None,
     };
-    let if_statement1_into: IfStatement = if_statement1.into();
+    let loop_statement = ast::LoopBodyStatement::Break;
+    let return_statement = if_condition_expr.clone();
+    let if_body = ast::IfBodyStatements::If(vec![
+        ast::IfBodyStatement::LetBinding(let_binding.clone()),
+        ast::IfBodyStatement::Binding(binding.clone()),
+        ast::IfBodyStatement::FunctionCall(fn_call.clone()),
+        ast::IfBodyStatement::If(if_statement2.clone()),
+        ast::IfBodyStatement::Loop(vec![loop_statement.clone()]),
+        ast::IfBodyStatement::Return(return_statement.clone()),
+    ]);
+    let mut if_statement1 = ast::IfStatement {
+        condition: if_condition.clone(),
+        body: if_body.clone(),
+        else_statement: None,
+        else_if_statement: None,
+    };
+    if_statement1.else_statement = Some(if_body.clone());
+    if_statement1.else_if_statement = Some(Box::new(if_statement1.clone()));
+    let if_statement1_into: IfStatement = if_statement1.clone().into();
     assert_eq!(
         if_statement1_into.condition,
-        IfCondition::Single(if_condition_expr.into())
+        IfCondition::Single(if_condition_expr.clone().into())
     );
+
+    let if_let_binding_into = IfBodyStatement::LetBinding(let_binding.into());
+    let if_binding_into = IfBodyStatement::Binding(binding.into());
+    let if_fn_call_into = IfBodyStatement::FunctionCall(fn_call.into());
+    let if_if_statement2_into = IfBodyStatement::If(if_statement2.into());
+    let loop_statement_into = IfBodyStatement::Loop(vec![loop_statement.into()]);
+    let return_statement_into = IfBodyStatement::Return(return_statement.into());
     assert_eq!(
         if_statement1_into.body,
-        IfBodyStatements::If(vec![IfBodyStatement::LetBinding(let_binding.into())])
+        IfBodyStatements::If(vec![
+            if_let_binding_into.clone(),
+            if_binding_into.clone(),
+            if_fn_call_into.clone(),
+            if_if_statement2_into.clone(),
+            loop_statement_into.clone(),
+            return_statement_into.clone()
+        ])
     );
-    assert!(if_statement1_into.else_statement.is_none());
-    assert!(if_statement1_into.else_if_statement.is_none());
+    assert_eq!(
+        if_statement1_into.clone().else_statement.unwrap(),
+        IfBodyStatements::If(vec![
+            if_let_binding_into,
+            if_binding_into,
+            if_fn_call_into,
+            if_if_statement2_into,
+            loop_statement_into,
+            return_statement_into
+        ])
+    );
+    let if_compare1 = *if_statement1_into.clone().else_if_statement.unwrap();
+    let if_compare2 = IfStatement {
+        else_if_statement: None,
+        ..if_statement1_into.clone()
+    };
+    assert_eq!(if_compare1, if_compare2);
+    assert_eq!(if_statement1.location(), CodeLocation::new(1, 0));
+    // For grcov
+    format!("{if_statement1:?}");
+}
+
+#[test]
+fn if_logic_transform() {
+    let if_condition_expr = ast::Expression {
+        expression_value: ast::ExpressionValue::PrimitiveValue(ast::PrimitiveValue::F32(1.2)),
+        operation: None,
+    };
+    let if_condition_expr_into: Expression = if_condition_expr.clone().into();
+    let expr_cond1 = ast::ExpressionCondition {
+        left: if_condition_expr.clone(),
+        condition: ast::Condition::Great,
+        right: if_condition_expr.clone(),
+    };
+    let expr_cond1_into: ExpressionCondition = expr_cond1.into();
+    assert_eq!(expr_cond1_into.left, if_condition_expr_into.clone());
+    assert_eq!(expr_cond1_into.right, if_condition_expr_into.clone());
+    assert_eq!(expr_cond1_into.condition, Condition::Great);
+
+    let expr_cond2 = ast::ExpressionCondition {
+        left: if_condition_expr.clone(),
+        condition: ast::Condition::Less,
+        right: if_condition_expr.clone(),
+    };
+    let expr_cond2_into: ExpressionCondition = expr_cond2.into();
+    assert_eq!(expr_cond2_into.left, if_condition_expr_into.clone());
+    assert_eq!(expr_cond2_into.right, if_condition_expr_into.clone());
+    assert_eq!(expr_cond2_into.condition, Condition::Less);
+
+    let expr_cond3 = ast::ExpressionCondition {
+        left: if_condition_expr.clone(),
+        condition: ast::Condition::Eq,
+        right: if_condition_expr.clone(),
+    };
+    let expr_cond3_into: ExpressionCondition = expr_cond3.into();
+    assert_eq!(expr_cond3_into.left, if_condition_expr_into.clone());
+    assert_eq!(expr_cond3_into.right, if_condition_expr_into.clone());
+    assert_eq!(expr_cond3_into.condition, Condition::Eq);
+
+    let expr_cond4 = ast::ExpressionCondition {
+        left: if_condition_expr.clone(),
+        condition: ast::Condition::GreatEq,
+        right: if_condition_expr.clone(),
+    };
+    let expr_cond4_into: ExpressionCondition = expr_cond4.into();
+    assert_eq!(expr_cond4_into.left, if_condition_expr_into.clone());
+    assert_eq!(expr_cond4_into.right, if_condition_expr_into.clone());
+    assert_eq!(expr_cond4_into.condition, Condition::GreatEq);
+
+    let expr_cond5 = ast::ExpressionCondition {
+        left: if_condition_expr.clone(),
+        condition: ast::Condition::LessEq,
+        right: if_condition_expr.clone(),
+    };
+    let expr_cond5_into: ExpressionCondition = expr_cond5.into();
+    assert_eq!(expr_cond5_into.left, if_condition_expr_into.clone());
+    assert_eq!(expr_cond5_into.right, if_condition_expr_into.clone());
+    assert_eq!(expr_cond5_into.condition, Condition::LessEq);
+
+    let expr_cond6 = ast::ExpressionCondition {
+        left: if_condition_expr.clone(),
+        condition: ast::Condition::NotEq,
+        right: if_condition_expr.clone(),
+    };
+    let expr_cond6_into: ExpressionCondition = expr_cond6.into();
+    assert_eq!(expr_cond6_into.left, if_condition_expr_into.clone());
+    assert_eq!(expr_cond6_into.right, if_condition_expr_into.clone());
+    assert_eq!(expr_cond6_into.condition, Condition::NotEq);
+
+    let logic_cond_and = ast::LogicCondition::And;
+    let logic_cond_and_into: LogicCondition = logic_cond_and.into();
+    assert_eq!(logic_cond_and_into, LogicCondition::And);
+
+    let logic_cond_and = ast::LogicCondition::Or;
+    let logic_cond_and_into: LogicCondition = logic_cond_and.into();
+    assert_eq!(logic_cond_and_into, LogicCondition::Or);
+
+    let let_binding = ast::LetBinding {
+        name: ast::ValueName::new(Ident::new("x")),
+        mutable: false,
+        value_type: None,
+        value: Box::new(ast::Expression {
+            expression_value: ast::ExpressionValue::PrimitiveValue(ast::PrimitiveValue::Bool(true)),
+            operation: None,
+        }),
+    };
+    let binding = ast::Binding {
+        name: ast::ValueName::new(Ident::new("x")),
+        value: Box::new(ast::Expression {
+            expression_value: ast::ExpressionValue::PrimitiveValue(ast::PrimitiveValue::Bool(true)),
+            operation: None,
+        }),
+    };
+    let fn_call = ast::FunctionCall {
+        name: ast::FunctionName::new(Ident::new("fn1")),
+        parameters: vec![],
+    };
+
+    let if_statement2 = ast::IfStatement {
+        condition: ast::IfCondition::Single(if_condition_expr.clone()),
+        body: ast::IfBodyStatements::If(vec![]),
+        else_statement: None,
+        else_if_statement: None,
+    };
+    let loop_statement = ast::LoopBodyStatement::Break;
+    let return_statement = if_condition_expr.clone();
+    let if_loop_body = ast::IfBodyStatements::Loop(vec![
+        ast::IfLoopBodyStatement::LetBinding(let_binding.clone()),
+        ast::IfLoopBodyStatement::Binding(binding.clone()),
+        ast::IfLoopBodyStatement::FunctionCall(fn_call.clone()),
+        ast::IfLoopBodyStatement::If(if_statement2.clone()),
+        ast::IfLoopBodyStatement::Loop(vec![loop_statement.clone()]),
+        ast::IfLoopBodyStatement::Return(return_statement.clone()),
+        ast::IfLoopBodyStatement::Break,
+        ast::IfLoopBodyStatement::Continue,
+    ]);
+
+    let expr_cond = ast::ExpressionCondition {
+        left: if_condition_expr.clone(),
+        condition: ast::Condition::Eq,
+        right: if_condition_expr.clone(),
+    };
+    let mut expr_logic_cond = ast::ExpressionLogicCondition {
+        left: expr_cond.clone(),
+        right: None,
+    };
+    expr_logic_cond.right = Some((ast::LogicCondition::And, Box::new(expr_logic_cond.clone())));
+    let if_logic_condition = ast::IfCondition::Logic(expr_logic_cond.clone());
+
+    let if_statement3 = ast::IfStatement {
+        condition: if_logic_condition.clone(),
+        body: if_loop_body,
+        else_statement: None,
+        else_if_statement: None,
+    };
+    // For grcov
+    format!("{if_statement3:?}");
+    let expr_logic_cond_into: ExpressionLogicCondition = expr_logic_cond.into();
+    assert_eq!(
+        expr_logic_cond_into.left,
+        ExpressionCondition {
+            left: if_condition_expr_into.clone(),
+            condition: Condition::Eq,
+            right: if_condition_expr_into,
+        }
+    );
+    let if_statement3_into: IfStatement = if_statement3.clone().into();
+    assert_eq!(
+        if_statement3_into.condition,
+        IfCondition::Logic(expr_logic_cond_into)
+    );
+    let if_let_binding_into = IfLoopBodyStatement::LetBinding(let_binding.into());
+    let if_binding_into = IfLoopBodyStatement::Binding(binding.into());
+    let if_fn_call_into = IfLoopBodyStatement::FunctionCall(fn_call.into());
+    let if_statement2_into = IfLoopBodyStatement::If(if_statement2.into());
+    let loop_statement_into = IfLoopBodyStatement::Loop(vec![loop_statement.into()]);
+    let return_statement_into = IfLoopBodyStatement::Return(return_statement.into());
+    assert_eq!(
+        if_statement3_into.body,
+        IfBodyStatements::Loop(vec![
+            if_let_binding_into,
+            if_binding_into,
+            if_fn_call_into,
+            if_statement2_into,
+            loop_statement_into,
+            return_statement_into,
+            IfLoopBodyStatement::Break,
+            IfLoopBodyStatement::Continue,
+        ])
+    );
+    assert!(if_statement3_into.else_if_statement.is_none());
+    assert!(if_statement3_into.else_if_statement.is_none());
 }

--- a/tests/if_tests.rs
+++ b/tests/if_tests.rs
@@ -912,7 +912,182 @@ fn if_body_statements() {
         Some((&label_loop_begin, &label_loop_end)),
     );
     assert!(t.is_empty_error());
-    // println!("{ctx2:#?}");
+
+    assert!(block_state.borrow().context.clone().get().is_empty());
+    assert!(block_state.borrow().parent.is_none());
+    assert_eq!(block_state.borrow().children.len(), 1);
+
+    let ctx = block_state.borrow().children[0].clone();
+    assert!(ctx.borrow().parent.is_some());
+    assert_eq!(ctx.borrow().children.len(), 2);
+
+    let stm_ctx = ctx.borrow().context.clone().get();
+    assert_eq!(stm_ctx.len(), 8);
+    assert_eq!(
+        stm_ctx[0],
+        SemanticStackContext::IfConditionExpression {
+            expr_result: ExpressionResult {
+                expr_type: Type::Primitive(PrimitiveTypes::U64),
+                expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::U64(1)),
+            },
+            label_if_begin: String::from("if_begin").into(),
+            label_if_end: String::from("if_end").into()
+        }
+    );
+    assert_eq!(
+        stm_ctx[1],
+        SemanticStackContext::SetLabel {
+            label: String::from("if_begin").into()
+        }
+    );
+    assert_eq!(
+        stm_ctx[2],
+        SemanticStackContext::LetBinding {
+            let_decl: Value {
+                inner_name: "x.0".into(),
+                inner_type: Type::Primitive(PrimitiveTypes::Bool),
+                mutable: true,
+                alloca: false,
+                malloc: false
+            },
+            expr_result: ExpressionResult {
+                expr_type: Type::Primitive(PrimitiveTypes::Bool),
+                expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::Bool(false)),
+            },
+        }
+    );
+    assert_eq!(
+        stm_ctx[3],
+        SemanticStackContext::Binding {
+            val: Value {
+                inner_name: "x.0".into(),
+                inner_type: Type::Primitive(PrimitiveTypes::Bool),
+                mutable: true,
+                alloca: false,
+                malloc: false
+            },
+            expr_result: ExpressionResult {
+                expr_type: Type::Primitive(PrimitiveTypes::Bool),
+                expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::Bool(true)),
+            },
+        }
+    );
+    assert_eq!(
+        stm_ctx[4],
+        SemanticStackContext::Call {
+            call: Function {
+                inner_name: String::from("fn2").into(),
+                inner_type: Type::Primitive(PrimitiveTypes::U16),
+                parameters: vec![],
+            },
+            params: vec![],
+        }
+    );
+    assert_eq!(
+        stm_ctx[5],
+        SemanticStackContext::JumpFunctionReturn {
+            expr_result: ExpressionResult {
+                expr_type: Type::Primitive(PrimitiveTypes::Bool),
+                expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::Bool(true)),
+            }
+        }
+    );
+    assert_eq!(
+        stm_ctx[6],
+        SemanticStackContext::JumpTo {
+            label: String::from("if_end").into()
+        }
+    );
+    assert_eq!(
+        stm_ctx[7],
+        SemanticStackContext::SetLabel {
+            label: String::from("if_end").into()
+        }
+    );
+
+    let ch_ctx1 = ctx.borrow().children[0].clone();
+    assert!(ch_ctx1.borrow().parent.is_some());
+    assert!(ch_ctx1.borrow().children.is_empty());
+
+    let ctx1 = ch_ctx1.borrow().context.clone().get();
+    assert_eq!(ctx1.len(), 4);
+    assert_eq!(
+        ctx1[0],
+        SemanticStackContext::IfConditionExpression {
+            expr_result: ExpressionResult {
+                expr_type: Type::Primitive(PrimitiveTypes::Bool),
+                expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::Bool(true)),
+            },
+            label_if_begin: String::from("if_begin.0").into(),
+            label_if_end: String::from("if_end").into()
+        }
+    );
+    assert_eq!(
+        ctx1[1],
+        SemanticStackContext::SetLabel {
+            label: String::from("if_begin.0").into()
+        }
+    );
+    assert_eq!(
+        ctx1[2],
+        SemanticStackContext::Call {
+            call: Function {
+                inner_name: String::from("fn2").into(),
+                inner_type: Type::Primitive(PrimitiveTypes::U16),
+                parameters: vec![],
+            },
+            params: vec![],
+        }
+    );
+    assert_eq!(
+        ctx1[3],
+        SemanticStackContext::JumpTo {
+            label: String::from("if_end").into()
+        }
+    );
+
+    let ch_ctx2 = ctx.borrow().children[1].clone();
+    assert!(ch_ctx2.borrow().parent.is_some());
+    assert!(ch_ctx2.borrow().children.is_empty());
+
+    let ctx2 = ch_ctx2.borrow().context.clone().get();
+    assert_eq!(ctx2.len(), 5);
+    assert_eq!(
+        ctx2[0],
+        SemanticStackContext::JumpTo {
+            label: String::from("loop_begin").into()
+        }
+    );
+
+    assert_eq!(
+        ctx2[1],
+        SemanticStackContext::SetLabel {
+            label: String::from("loop_begin").into()
+        }
+    );
+    assert_eq!(
+        ctx2[2],
+        SemanticStackContext::Call {
+            call: Function {
+                inner_name: String::from("fn2").into(),
+                inner_type: Type::Primitive(PrimitiveTypes::U16),
+                parameters: vec![],
+            },
+            params: vec![],
+        }
+    );
+    assert_eq!(
+        ctx2[3],
+        SemanticStackContext::JumpTo {
+            label: String::from("loop_begin").into()
+        }
+    );
+    assert_eq!(
+        ctx2[4],
+        SemanticStackContext::SetLabel {
+            label: String::from("loop_end").into()
+        }
+    );
 }
 
 #[test]

--- a/tests/loop_tests.rs
+++ b/tests/loop_tests.rs
@@ -48,6 +48,8 @@ fn loop_transform() {
         ast::LoopBodyStatement::Break,
         ast::LoopBodyStatement::Continue,
     ];
+    // For grcove
+    format!("{loop_stmts:#?}");
     for loop_stmt in loop_stmts {
         let loop_stmt_into: LoopBodyStatement = loop_stmt.into();
         match loop_stmt_into {

--- a/tests/loop_tests.rs
+++ b/tests/loop_tests.rs
@@ -1,0 +1,70 @@
+use semantic_analyzer::ast;
+use semantic_analyzer::ast::Ident;
+use semantic_analyzer::types::condition::LoopBodyStatement;
+
+#[test]
+fn loop_transform() {
+    let let_binding = ast::LetBinding {
+        name: ast::ValueName::new(Ident::new("x")),
+        mutable: false,
+        value_type: None,
+        value: Box::new(ast::Expression {
+            expression_value: ast::ExpressionValue::PrimitiveValue(ast::PrimitiveValue::Bool(true)),
+            operation: None,
+        }),
+    };
+    let binding = ast::Binding {
+        name: ast::ValueName::new(Ident::new("x")),
+        value: Box::new(ast::Expression {
+            expression_value: ast::ExpressionValue::PrimitiveValue(ast::PrimitiveValue::Bool(true)),
+            operation: None,
+        }),
+    };
+    let fn_call = ast::FunctionCall {
+        name: ast::FunctionName::new(Ident::new("fn1")),
+        parameters: vec![],
+    };
+    let if_statement = ast::IfStatement {
+        condition: ast::IfCondition::Single(ast::Expression {
+            expression_value: ast::ExpressionValue::PrimitiveValue(ast::PrimitiveValue::F32(1.2)),
+            operation: None,
+        }),
+        body: ast::IfBodyStatements::If(vec![]),
+        else_statement: None,
+        else_if_statement: None,
+    };
+    let loop_statement = ast::LoopBodyStatement::Break;
+    let return_statement = ast::Expression {
+        expression_value: ast::ExpressionValue::PrimitiveValue(ast::PrimitiveValue::F32(1.2)),
+        operation: None,
+    };
+    let loop_stmts = vec![
+        ast::LoopBodyStatement::LetBinding(let_binding.clone()),
+        ast::LoopBodyStatement::Binding(binding.clone()),
+        ast::LoopBodyStatement::FunctionCall(fn_call.clone()),
+        ast::LoopBodyStatement::If(if_statement.clone()),
+        ast::LoopBodyStatement::Loop(vec![loop_statement.clone()]),
+        ast::LoopBodyStatement::Return(return_statement.clone()),
+        ast::LoopBodyStatement::Break,
+        ast::LoopBodyStatement::Continue,
+    ];
+    for loop_stmt in loop_stmts {
+        let loop_stmt_into: LoopBodyStatement = loop_stmt.into();
+        match loop_stmt_into {
+            LoopBodyStatement::LetBinding(val) => assert_eq!(val, let_binding.clone().into()),
+            LoopBodyStatement::Binding(val) => assert_eq!(val, binding.clone().into()),
+            LoopBodyStatement::FunctionCall(val) => assert_eq!(val, fn_call.clone().into()),
+            LoopBodyStatement::If(val) => assert_eq!(val, if_statement.clone().into()),
+            LoopBodyStatement::Loop(val) => assert_eq!(val, vec![loop_statement.clone().into()]),
+            LoopBodyStatement::Return(val) => assert_eq!(val, return_statement.clone().into()),
+            LoopBodyStatement::Break => assert_eq!(
+                LoopBodyStatement::Break,
+                ast::LoopBodyStatement::Break.into()
+            ),
+            LoopBodyStatement::Continue => assert_eq!(
+                LoopBodyStatement::Continue,
+                ast::LoopBodyStatement::Continue.into()
+            ),
+        }
+    }
+}

--- a/tests/loop_tests.rs
+++ b/tests/loop_tests.rs
@@ -1,6 +1,12 @@
+use crate::utils::SemanticTest;
 use semantic_analyzer::ast;
 use semantic_analyzer::ast::Ident;
+use semantic_analyzer::types::block_state::BlockState;
 use semantic_analyzer::types::condition::LoopBodyStatement;
+use std::cell::RefCell;
+use std::rc::Rc;
+
+mod utils;
 
 #[test]
 fn loop_transform() {
@@ -69,4 +75,84 @@ fn loop_transform() {
             ),
         }
     }
+}
+
+#[test]
+fn loop_statements() {
+    let block_state = Rc::new(RefCell::new(BlockState::new(None)));
+    let mut t = SemanticTest::new();
+
+    let fn2 = ast::FunctionStatement {
+        name: ast::FunctionName::new(Ident::new("fn2")),
+        parameters: vec![],
+        result_type: ast::Type::Primitive(ast::PrimitiveTypes::U16),
+        body: vec![ast::BodyStatement::Expression(ast::Expression {
+            expression_value: ast::ExpressionValue::PrimitiveValue(ast::PrimitiveValue::U16(23)),
+            operation: None,
+        })],
+    };
+    t.state.function_declaration(&fn2);
+
+    let loop_body_let_binding = ast::LoopBodyStatement::LetBinding(ast::LetBinding {
+        name: ast::ValueName::new(Ident::new("x")),
+        mutable: true,
+        value_type: None,
+        value: Box::new(ast::Expression {
+            expression_value: ast::ExpressionValue::PrimitiveValue(ast::PrimitiveValue::Bool(
+                false,
+            )),
+            operation: None,
+        }),
+    });
+    let loop_body_binding = ast::LoopBodyStatement::Binding(ast::Binding {
+        name: ast::ValueName::new(Ident::new("x")),
+        value: Box::new(ast::Expression {
+            expression_value: ast::ExpressionValue::PrimitiveValue(ast::PrimitiveValue::Bool(true)),
+            operation: None,
+        }),
+    });
+    let loop_body_fn_call = ast::LoopBodyStatement::FunctionCall(ast::FunctionCall {
+        name: ast::FunctionName::new(Ident::new("fn2")),
+        parameters: vec![],
+    });
+    let loop_body_if = ast::LoopBodyStatement::If(ast::IfStatement {
+        condition: ast::IfCondition::Single(ast::Expression {
+            expression_value: ast::ExpressionValue::PrimitiveValue(ast::PrimitiveValue::Bool(true)),
+            operation: None,
+        }),
+        body: ast::IfBodyStatements::Loop(vec![ast::IfLoopBodyStatement::FunctionCall(
+            ast::FunctionCall {
+                name: ast::FunctionName::new(Ident::new("fn2")),
+                parameters: vec![],
+            },
+        )]),
+        else_statement: None,
+        else_if_statement: None,
+    });
+    let loop_body_loop = ast::LoopBodyStatement::Loop(vec![ast::LoopBodyStatement::FunctionCall(
+        ast::FunctionCall {
+            name: ast::FunctionName::new(Ident::new("fn2")),
+            parameters: vec![],
+        },
+    )]);
+    let loop_body_return = ast::LoopBodyStatement::Return(ast::Expression {
+        expression_value: ast::ExpressionValue::PrimitiveValue(ast::PrimitiveValue::Bool(true)),
+        operation: None,
+    });
+    let loop_body_break = ast::LoopBodyStatement::Break;
+    let loop_body_continue = ast::LoopBodyStatement::Continue;
+
+    let loop_stmt = [
+        loop_body_let_binding,
+        loop_body_binding,
+        loop_body_fn_call,
+        loop_body_if,
+        loop_body_loop,
+        loop_body_break,
+        loop_body_continue,
+        loop_body_return,
+    ];
+    t.state.loop_statement(&loop_stmt, &block_state);
+    // println!("{:#?}", t.state);
+    assert!(t.is_empty_error());
 }

--- a/tests/loop_tests.rs
+++ b/tests/loop_tests.rs
@@ -167,22 +167,22 @@ fn loop_statements() {
     assert!(ctx.borrow().parent.is_some());
     assert_eq!(ctx.borrow().children.len(), 2);
 
-    let ctx1 = ctx.borrow().context.clone().get();
-    assert_eq!(ctx1.len(), 9);
+    let stm_ctx = ctx.borrow().context.clone().get();
+    assert_eq!(stm_ctx.len(), 10);
     assert_eq!(
-        ctx1[0],
+        stm_ctx[0],
         SemanticStackContext::JumpTo {
             label: String::from("loop_begin").into()
         }
     );
     assert_eq!(
-        ctx1[1],
+        stm_ctx[1],
         SemanticStackContext::SetLabel {
             label: String::from("loop_begin").into()
         }
     );
     assert_eq!(
-        ctx1[2],
+        stm_ctx[2],
         SemanticStackContext::LetBinding {
             let_decl: Value {
                 inner_name: "x.0".into(),
@@ -198,7 +198,7 @@ fn loop_statements() {
         }
     );
     assert_eq!(
-        ctx1[3],
+        stm_ctx[3],
         SemanticStackContext::Binding {
             val: Value {
                 inner_name: "x.0".into(),
@@ -214,7 +214,7 @@ fn loop_statements() {
         }
     );
     assert_eq!(
-        ctx1[4],
+        stm_ctx[4],
         SemanticStackContext::Call {
             call: Function {
                 inner_name: String::from("fn2").into(),
@@ -225,19 +225,19 @@ fn loop_statements() {
         }
     );
     assert_eq!(
-        ctx1[5],
+        stm_ctx[5],
         SemanticStackContext::JumpTo {
             label: String::from("loop_end").into()
         }
     );
     assert_eq!(
-        ctx1[6],
+        stm_ctx[6],
         SemanticStackContext::JumpTo {
             label: String::from("loop_begin").into()
         }
     );
     assert_eq!(
-        ctx1[7],
+        stm_ctx[7],
         SemanticStackContext::JumpFunctionReturn {
             expr_result: ExpressionResult {
                 expr_type: Type::Primitive(PrimitiveTypes::Bool),
@@ -246,7 +246,13 @@ fn loop_statements() {
         }
     );
     assert_eq!(
-        ctx1[8],
+        stm_ctx[8],
+        SemanticStackContext::JumpTo {
+            label: String::from("loop_begin").into()
+        }
+    );
+    assert_eq!(
+        stm_ctx[9],
         SemanticStackContext::SetLabel {
             label: String::from("loop_end").into()
         }
@@ -256,10 +262,10 @@ fn loop_statements() {
     assert!(ch_ctx1.borrow().parent.is_some());
     assert!(ch_ctx1.borrow().children.is_empty());
 
-    let ctx2 = ch_ctx1.borrow().context.clone().get();
-    assert_eq!(ctx2.len(), 5);
+    let ctx1 = ch_ctx1.borrow().context.clone().get();
+    assert_eq!(ctx1.len(), 5);
     assert_eq!(
-        ctx2[0],
+        ctx1[0],
         SemanticStackContext::IfConditionExpression {
             expr_result: ExpressionResult {
                 expr_type: Type::Primitive(PrimitiveTypes::Bool),
@@ -270,9 +276,51 @@ fn loop_statements() {
         }
     );
     assert_eq!(
-        ctx2[1],
+        ctx1[1],
         SemanticStackContext::SetLabel {
             label: String::from("if_begin").into()
+        }
+    );
+    assert_eq!(
+        ctx1[2],
+        SemanticStackContext::Call {
+            call: Function {
+                inner_name: String::from("fn2").into(),
+                inner_type: Type::Primitive(PrimitiveTypes::U16),
+                parameters: vec![],
+            },
+            params: vec![],
+        }
+    );
+    assert_eq!(
+        ctx1[3],
+        SemanticStackContext::JumpTo {
+            label: String::from("if_end").into()
+        }
+    );
+    assert_eq!(
+        ctx1[4],
+        SemanticStackContext::SetLabel {
+            label: String::from("if_end").into()
+        }
+    );
+
+    let ch_ctx2 = ctx.borrow().children[1].clone();
+    assert!(ch_ctx2.borrow().parent.is_some());
+    assert!(ch_ctx2.borrow().children.is_empty());
+
+    let ctx2 = ch_ctx2.borrow().context.clone().get();
+    assert_eq!(ctx2.len(), 5);
+    assert_eq!(
+        ctx2[0],
+        SemanticStackContext::JumpTo {
+            label: String::from("loop_begin.0").into()
+        }
+    );
+    assert_eq!(
+        ctx2[1],
+        SemanticStackContext::SetLabel {
+            label: String::from("loop_begin.0").into()
         }
     );
     assert_eq!(
@@ -289,47 +337,11 @@ fn loop_statements() {
     assert_eq!(
         ctx2[3],
         SemanticStackContext::JumpTo {
-            label: String::from("if_end").into()
+            label: String::from("loop_begin.0").into()
         }
     );
     assert_eq!(
         ctx2[4],
-        SemanticStackContext::SetLabel {
-            label: String::from("if_end").into()
-        }
-    );
-
-    let ch_ctx2 = ctx.borrow().children[1].clone();
-    assert!(ch_ctx2.borrow().parent.is_some());
-    assert!(ch_ctx2.borrow().children.is_empty());
-
-    let ctx3 = ch_ctx2.borrow().context.clone().get();
-    assert_eq!(ctx3.len(), 4);
-    assert_eq!(
-        ctx3[0],
-        SemanticStackContext::JumpTo {
-            label: String::from("loop_begin.0").into()
-        }
-    );
-    assert_eq!(
-        ctx3[1],
-        SemanticStackContext::SetLabel {
-            label: String::from("loop_begin.0").into()
-        }
-    );
-    assert_eq!(
-        ctx3[2],
-        SemanticStackContext::Call {
-            call: Function {
-                inner_name: String::from("fn2").into(),
-                inner_type: Type::Primitive(PrimitiveTypes::U16),
-                parameters: vec![],
-            },
-            params: vec![],
-        }
-    );
-    assert_eq!(
-        ctx3[3],
         SemanticStackContext::SetLabel {
             label: String::from("loop_end.0").into()
         }

--- a/tests/main_tests.rs
+++ b/tests/main_tests.rs
@@ -1,0 +1,22 @@
+use semantic_analyzer::ast;
+use semantic_analyzer::ast::{ConstantName, Ident};
+
+#[test]
+fn main_transform() {
+    let imports: ast::ImportPath = vec![ast::ImportName::new(Ident::new("import1"))];
+    let import_stm = ast::MainStatement::Import(imports);
+    let constant1 = ast::Constant {
+        name: ast::ConstantName::new(Ident::new("const1")),
+        constant_type: ast::Type::Primitive(ast::PrimitiveTypes::None),
+        constant_value: ast::ConstantExpression {
+            value: ast::ConstantValue::Constant(ConstantName::new(Ident::new("const2"))),
+            operation: None,
+        },
+    };
+    let constant_stm = ast::MainStatement::Constant(constant1);
+	let fn1 = ast::FunctionStatement{
+		name:ast::FunctionName::new(Ident::new("fn1"));
+	};
+	let fn_stm = ast::MainStatement::Function(fn1);
+    let _main_stm: ast::Main = vec![import_stm.clone(), constant_stm.clone()];
+}

--- a/tests/main_tests.rs
+++ b/tests/main_tests.rs
@@ -141,6 +141,14 @@ fn main_run() {
     assert!(ctx2.children.is_empty());
     assert!(ctx2.parent.is_none());
 
+    let ch_ctx1 = ctx1.children[0].clone();
+    assert!(ch_ctx1.borrow().parent.is_some());
+    assert!(ch_ctx1.borrow().children.is_empty());
+
+    let ch_ctx2 = ctx1.children[1].clone();
+    assert!(ch_ctx2.borrow().parent.is_some());
+    assert!(ch_ctx2.borrow().children.is_empty());
+
     // Semantic stack context for the block fn1
     let st_ctx1 = ctx1.context.clone().get();
     assert_eq!(st_ctx1.len(), 4);
@@ -208,6 +216,81 @@ fn main_run() {
                 expr_type: Type::Primitive(PrimitiveTypes::U16),
                 expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::U16(23)),
             }
+        }
+    );
+
+    let st_ch_ctx1 = ch_ctx1.borrow().context.clone().get();
+    assert_eq!(st_ch_ctx1.len(), 5);
+    assert_eq!(
+        st_ch_ctx1[0],
+        SemanticStackContext::IfConditionExpression {
+            expr_result: ExpressionResult {
+                expr_type: Type::Primitive(PrimitiveTypes::Bool),
+                expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::Bool(true)),
+            },
+            label_if_begin: String::from("if_begin").into(),
+            label_if_end: String::from("if_end").into()
+        }
+    );
+    assert_eq!(
+        st_ch_ctx1[1],
+        SemanticStackContext::SetLabel {
+            label: String::from("if_begin").into()
+        }
+    );
+    assert_eq!(
+        st_ch_ctx1[2],
+        SemanticStackContext::Call {
+            call: Function {
+                inner_name: String::from("fn2").into(),
+                inner_type: Type::Primitive(PrimitiveTypes::U16),
+                parameters: vec![],
+            },
+            params: vec![],
+        }
+    );
+    assert_eq!(
+        st_ch_ctx1[3],
+        SemanticStackContext::JumpTo {
+            label: String::from("if_end").into()
+        }
+    );
+    assert_eq!(
+        st_ch_ctx1[4],
+        SemanticStackContext::SetLabel {
+            label: String::from("if_end").into()
+        }
+    );
+
+    let st_ch_ctx2 = ch_ctx2.borrow().context.clone().get();
+    assert_eq!(st_ch_ctx2.len(), 4);
+    assert_eq!(
+        st_ch_ctx2[0],
+        SemanticStackContext::JumpTo {
+            label: String::from("loop_begin").into()
+        }
+    );
+    assert_eq!(
+        st_ch_ctx2[1],
+        SemanticStackContext::SetLabel {
+            label: String::from("loop_begin").into()
+        }
+    );
+    assert_eq!(
+        st_ch_ctx2[2],
+        SemanticStackContext::Call {
+            call: Function {
+                inner_name: String::from("fn2").into(),
+                inner_type: Type::Primitive(PrimitiveTypes::U16),
+                parameters: vec![],
+            },
+            params: vec![],
+        }
+    );
+    assert_eq!(
+        st_ch_ctx2[3],
+        SemanticStackContext::SetLabel {
+            label: String::from("loop_end").into()
         }
     );
 

--- a/tests/main_tests.rs
+++ b/tests/main_tests.rs
@@ -5,7 +5,7 @@ use semantic_analyzer::types::{
     expression::{ExpressionResult, ExpressionResultValue},
     semantic::SemanticStackContext,
     types::{PrimitiveTypes, Type},
-    PrimitiveValue,
+    Function, PrimitiveValue, Value,
 };
 
 mod utils;
@@ -46,7 +46,7 @@ fn main_run() {
     let body_binding = ast::BodyStatement::Binding(ast::Binding {
         name: ast::ValueName::new(Ident::new("x")),
         value: Box::new(ast::Expression {
-            expression_value: ast::ExpressionValue::PrimitiveValue(ast::PrimitiveValue::F32(0.1)),
+            expression_value: ast::ExpressionValue::PrimitiveValue(ast::PrimitiveValue::Bool(true)),
             operation: None,
         }),
     });
@@ -145,6 +145,50 @@ fn main_run() {
     let st_ctx1 = ctx1.context.clone().get();
     assert_eq!(st_ctx1.len(), 4);
     assert_eq!(
+        st_ctx1[0],
+        SemanticStackContext::LetBinding {
+            let_decl: Value {
+                inner_name: "x.0".into(),
+                inner_type: Type::Primitive(PrimitiveTypes::Bool),
+                mutable: true,
+                alloca: false,
+                malloc: false
+            },
+            expr_result: ExpressionResult {
+                expr_type: Type::Primitive(PrimitiveTypes::Bool),
+                expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::Bool(false)),
+            },
+        }
+    );
+    assert_eq!(
+        st_ctx1[1],
+        SemanticStackContext::Binding {
+            val: Value {
+                inner_name: "x.0".into(),
+                inner_type: Type::Primitive(PrimitiveTypes::Bool),
+                mutable: true,
+                alloca: false,
+                malloc: false
+            },
+            expr_result: ExpressionResult {
+                expr_type: Type::Primitive(PrimitiveTypes::Bool),
+                expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::Bool(true)),
+            },
+        }
+    );
+    assert_eq!(
+        st_ctx1[2],
+        SemanticStackContext::Call {
+            call: Function {
+                inner_name: String::from("fn2").into(),
+                inner_type: Type::Primitive(PrimitiveTypes::U16),
+                parameters: vec![],
+            },
+            params: vec![],
+        }
+    );
+
+    assert_eq!(
         st_ctx1[3],
         SemanticStackContext::ExpressionFunctionReturn {
             expr_result: ExpressionResult {
@@ -186,6 +230,12 @@ fn main_run() {
         st_global_context[2],
         SemanticStackContext::FunctionDeclaration {
             fn_decl: fn1.into()
+        }
+    );
+    assert_eq!(
+        st_global_context[3],
+        SemanticStackContext::FunctionDeclaration {
+            fn_decl: fn2.into()
         }
     );
 }

--- a/tests/main_tests.rs
+++ b/tests/main_tests.rs
@@ -1,22 +1,108 @@
-use semantic_analyzer::ast;
-use semantic_analyzer::ast::{ConstantName, Ident};
+use crate::utils::SemanticTest;
+use semantic_analyzer::ast::{self, GetName, Ident};
+use semantic_analyzer::types::{
+    expression::{ExpressionResult, ExpressionResultValue},
+    semantic::SemanticStackContext,
+    types::{PrimitiveTypes, Type},
+    PrimitiveValue,
+};
+
+mod utils;
 
 #[test]
-fn main_transform() {
+fn main_run() {
+    let mut t = SemanticTest::new();
     let imports: ast::ImportPath = vec![ast::ImportName::new(Ident::new("import1"))];
     let import_stm = ast::MainStatement::Import(imports);
+
     let constant1 = ast::Constant {
         name: ast::ConstantName::new(Ident::new("const1")),
         constant_type: ast::Type::Primitive(ast::PrimitiveTypes::None),
         constant_value: ast::ConstantExpression {
-            value: ast::ConstantValue::Constant(ConstantName::new(Ident::new("const2"))),
+            value: ast::ConstantValue::Constant(ast::ConstantName::new(Ident::new("const2"))),
             operation: None,
         },
     };
-    let constant_stm = ast::MainStatement::Constant(constant1);
-	let fn1 = ast::FunctionStatement{
-		name:ast::FunctionName::new(Ident::new("fn1"));
-	};
-	let fn_stm = ast::MainStatement::Function(fn1);
-    let _main_stm: ast::Main = vec![import_stm.clone(), constant_stm.clone()];
+    let constant_stm = ast::MainStatement::Constant(constant1.clone());
+
+    let ty = ast::StructTypes {
+        name: Ident::new("StructType"),
+        attributes: vec![],
+    };
+    let ty_stm = ast::MainStatement::Types(ty.clone());
+
+    let body_return = ast::BodyStatement::Return(ast::Expression {
+        expression_value: ast::ExpressionValue::PrimitiveValue(ast::PrimitiveValue::Bool(true)),
+        operation: None,
+    });
+    let fn1 = ast::FunctionStatement {
+        name: ast::FunctionName::new(Ident::new("fn1")),
+        parameters: vec![],
+        result_type: ast::Type::Primitive(ast::PrimitiveTypes::Bool),
+        body: vec![body_return.clone()],
+    };
+    let fn_stm = ast::MainStatement::Function(fn1.clone());
+    let main_stm: ast::Main = vec![
+        import_stm.clone(),
+        constant_stm.clone(),
+        ty_stm.clone(),
+        fn_stm.clone(),
+    ];
+    t.state.run(&main_stm);
+    assert!(t.is_empty_error());
+
+    assert_eq!(
+        t.state
+            .global
+            .constants
+            .get(&constant1.clone().name().into())
+            .unwrap(),
+        &(constant1.clone().into())
+    );
+    assert_eq!(
+        t.state.global.types.get(&ty.clone().name().into()).unwrap(),
+        &Type::Struct(ty.clone().into())
+    );
+    let fn_sstate = t
+        .state
+        .global
+        .functions
+        .get(&fn1.clone().name().into())
+        .unwrap();
+    assert_eq!(fn_sstate.inner_name, fn1.name.clone().into());
+    assert_eq!(fn_sstate.inner_type, fn1.result_type.clone().into());
+    assert!(fn_sstate.parameters.is_empty());
+
+    assert_eq!(t.state.context.len(), 1);
+    let st = t.state.context[0].borrow().context.clone().get();
+    assert_eq!(st.len(), 1);
+    assert_eq!(
+        st[0],
+        SemanticStackContext::ExpressionFunctionReturnWithLabel {
+            expr_result: ExpressionResult {
+                expr_type: Type::Primitive(PrimitiveTypes::Bool),
+                expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::Bool(true)),
+            }
+        }
+    );
+    let st_context = t.state.global.context.get();
+    assert_eq!(st_context.len(), 3);
+    assert_eq!(
+        st_context[0],
+        SemanticStackContext::Types {
+            type_decl: ty.into()
+        }
+    );
+    assert_eq!(
+        st_context[1],
+        SemanticStackContext::Constant {
+            const_decl: constant1.into()
+        }
+    );
+    assert_eq!(
+        st_context[2],
+        SemanticStackContext::FunctionDeclaration {
+            fn_decl: fn1.into()
+        }
+    );
 }

--- a/tests/main_tests.rs
+++ b/tests/main_tests.rs
@@ -263,7 +263,7 @@ fn main_run() {
     );
 
     let st_ch_ctx2 = ch_ctx2.borrow().context.clone().get();
-    assert_eq!(st_ch_ctx2.len(), 4);
+    assert_eq!(st_ch_ctx2.len(), 5);
     assert_eq!(
         st_ch_ctx2[0],
         SemanticStackContext::JumpTo {
@@ -289,6 +289,12 @@ fn main_run() {
     );
     assert_eq!(
         st_ch_ctx2[3],
+        SemanticStackContext::JumpTo {
+            label: String::from("loop_begin").into()
+        }
+    );
+    assert_eq!(
+        st_ch_ctx2[4],
         SemanticStackContext::SetLabel {
             label: String::from("loop_end").into()
         }


### PR DESCRIPTION
## Description

### Fixes 

- [x] Fixed issue #8 with multiple returns for the `function-body` semantic analysis.
- [x] Fixed `If-loop` label parameters fail when missing label parameters for the `loop`.
- [x] Fixed issue #11 and only one `if-end` label exists for the `if-condition`.
- [x] Fixed issue #12 for loop-body repeatition and extended tests for that.

### Tests

Extended semantic analyzer tests:
- [x] if-conditions
- [x] loops
- [x] function-body
- [x] main-run
- [x] covered with tests all `SemanticStackContext` instructions

#### Coverage

💯 100% tests coverage


