### PR TITLE
Feat: refactor `if-end` jump logic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-analyzer"
-version = "0.2.4"
+version = "0.2.5"
 authors = ["Evgeny Ukhanov <mrlsd@ya.ru>"]
 description = "Semantic analyzer library for compilers written in Rust for semantic analysis of programming languages AST"
 keywords = ["compiler", "semantic-analisis", "semantic-alalyzer", "compiler-design", "semantic"]

--- a/src/semantic.rs
+++ b/src/semantic.rs
@@ -854,12 +854,14 @@ impl State {
                 );
             }
         }
-        // Codegen for jump to if-end statement - return to program flow
-        // TODO: issue #9
-        if_body_state
-            .borrow_mut()
-            .context
-            .jump_to(label_if_end.clone());
+        // Codegen for jump to if-end statement - return to program flow.
+        // If return is set do not add jump-to-end label.
+        if !if_body_state.borrow().manual_return {
+            if_body_state
+                .borrow_mut()
+                .context
+                .jump_to(label_if_end.clone());
+        }
 
         // Check else statements: else, else-if
         if is_else {
@@ -901,11 +903,13 @@ impl State {
                 }
 
                 // Codegen for jump to if-end statement -return to program flow
-                // TODO: issue #9
-                if_body_state
-                    .borrow_mut()
-                    .context
-                    .jump_to(label_if_end.clone());
+                // If return is set do not add jump-to-end label.
+                if !if_body_state.borrow().manual_return {
+                    if_body_state
+                        .borrow_mut()
+                        .context
+                        .jump_to(label_if_end.clone());
+                }
             } else if let Some(else_if_statement) = &data.else_if_statement {
                 // Analyse  else-if statement
                 // Set `label_if_end` to indicate single if-end point

--- a/tests/if_tests.rs
+++ b/tests/if_tests.rs
@@ -715,7 +715,7 @@ fn else_if_statement() {
     assert!(ch_ctx3.borrow().children.is_empty());
 
     let ctx1 = ch_ctx1.borrow().context.clone().get();
-    assert_eq!(ctx1.len(), 6);
+    assert_eq!(ctx1.len(), 5);
     assert_eq!(
         ctx1[0],
         SemanticStackContext::IfConditionExpression {
@@ -744,25 +744,19 @@ fn else_if_statement() {
     );
     assert_eq!(
         ctx1[3],
-        SemanticStackContext::JumpTo {
-            label: String::from("if_end").into()
-        }
-    );
-    assert_eq!(
-        ctx1[4],
         SemanticStackContext::SetLabel {
             label: String::from("if_else").into()
         }
     );
     assert_eq!(
-        ctx1[5],
+        ctx1[4],
         SemanticStackContext::SetLabel {
             label: String::from("if_end").into()
         }
     );
 
     let ctx2 = ch_ctx2.borrow().context.clone().get();
-    assert_eq!(ctx2.len(), 6);
+    assert_eq!(ctx2.len(), 4);
     assert_eq!(
         ctx2[0],
         SemanticStackContext::IfConditionExpression {
@@ -791,20 +785,8 @@ fn else_if_statement() {
     );
     assert_eq!(
         ctx2[3],
-        SemanticStackContext::JumpTo {
-            label: String::from("if_end").into()
-        }
-    );
-    assert_eq!(
-        ctx2[4],
         SemanticStackContext::SetLabel {
             label: String::from("if_else.0").into()
-        }
-    );
-    assert_eq!(
-        ctx2[5],
-        SemanticStackContext::JumpTo {
-            label: String::from("if_end").into()
         }
     );
 
@@ -922,7 +904,7 @@ fn if_body_statements() {
     assert_eq!(ctx.borrow().children.len(), 2);
 
     let stm_ctx = ctx.borrow().context.clone().get();
-    assert_eq!(stm_ctx.len(), 8);
+    assert_eq!(stm_ctx.len(), 7);
     assert_eq!(
         stm_ctx[0],
         SemanticStackContext::IfConditionExpression {
@@ -994,12 +976,6 @@ fn if_body_statements() {
     );
     assert_eq!(
         stm_ctx[6],
-        SemanticStackContext::JumpTo {
-            label: String::from("if_end").into()
-        }
-    );
-    assert_eq!(
-        stm_ctx[7],
         SemanticStackContext::SetLabel {
             label: String::from("if_end").into()
         }
@@ -1206,7 +1182,7 @@ fn if_loop_body_statements() {
     assert_eq!(ctx.borrow().children.len(), 2);
 
     let stm_ctx = ctx.borrow().context.clone().get();
-    assert_eq!(stm_ctx.len(), 10);
+    assert_eq!(stm_ctx.len(), 9);
     assert_eq!(
         stm_ctx[0],
         SemanticStackContext::IfConditionExpression {
@@ -1290,12 +1266,6 @@ fn if_loop_body_statements() {
     );
     assert_eq!(
         stm_ctx[8],
-        SemanticStackContext::JumpTo {
-            label: String::from("if_end").into()
-        }
-    );
-    assert_eq!(
-        stm_ctx[9],
         SemanticStackContext::SetLabel {
             label: String::from("if_end").into()
         }

--- a/tests/main_tests.rs
+++ b/tests/main_tests.rs
@@ -466,7 +466,7 @@ fn if_return_from_function() {
 
     // Children semantic stack context for the block
     let st_children_ctx = children_ctx.context.clone().get();
-    assert_eq!(st_children_ctx.len(), 5);
+    assert_eq!(st_children_ctx.len(), 4);
     assert_eq!(
         st_children_ctx[0],
         SemanticStackContext::IfConditionExpression {
@@ -495,12 +495,6 @@ fn if_return_from_function() {
     );
     assert_eq!(
         st_children_ctx[3],
-        SemanticStackContext::JumpTo {
-            label: String::from("if_end").into()
-        }
-    );
-    assert_eq!(
-        st_children_ctx[4],
         SemanticStackContext::SetLabel {
             label: String::from("if_end").into()
         }


### PR DESCRIPTION
## Description

Refactored `if-end` jump logic for `if-condition` state. Related to issue #9.

### `If-body` block state

For the `if-body` block state, when called `return` anyway after this the `JumpTo if-end` instruction is called. It's redundant, refactored, and added an additional checks for label instruction `JumpTo` is `manual-return` for the current block state. If `manual-return` is set `JumpTo` context instruction is removed.

### `function-body` block state

For the `function-body` block state should be added an additional check for `manual-return`. If it is set to `true` add the label `return` before the `return` instruction and also add the `return` instruction itself.

### Other cases
- [x] Checked the same cases for the `if-else` statement and refactored.
- [x] Checked the same cases for the `if-else-if` statement - doesn't exist.
- [x] Checked the same cases for the `loop` statement, as a conclusion: it's the only case for the `if-condition` statement.