### PR TITLE
Feat: extend SemanticStack with registers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-analyzer"
-version = "0.2.6"
+version = "0.3.0"
 authors = ["Evgeny Ukhanov <mrlsd@ya.ru>"]
 description = "Semantic analyzer library for compilers written in Rust for semantic analysis of programming languages AST"
 keywords = ["compiler", "semantic-analisis", "semantic-alalyzer", "compiler-design", "semantic"]

--- a/README.md
+++ b/README.md
@@ -53,14 +53,14 @@ Supported condition expressions and condition expression correctness check.
 - **Building the Symbol Table**: For analyzing used the symbol table as data structure used by the semantic analyzer to keep track of 
 symbols (variables, functions, constants) in the source code. Each entry in the symbol table contains the symbol's name, type, and scope related for block state, and other relevant information.
 
-### Semantic State Tree
+### 🌳 Semantic State Tree
 
 The result of executing and passing stages of the semantic analyzer is: **Semantic State Tree**.
 
 This can be used for Intermediate Code Generation, for further passes
 semantic tree optimizations, linting, backend codegen (like LLVM) to target machine.
 
-#### Structure of Semantic State Tree 
+#### 🌲 Structure of Semantic State Tree 
 
 - **blocks state** and related block state child branches. It's a basic
 entity for scopes: variables, blocks (function, if, loop). 
@@ -87,7 +87,7 @@ However, parent elements cannot access child elements, which effectively limits 
 
 All of that source data, that can be used for Intermediate Representation for next optimizations and compilers codegen.
 
-### Subset of programming languages
+### 🧺 Subset of programming languages
 
 The input parameter for the analyzer is a predefined
 AST (abstract syntax tree). As a library for building AST and the only dependency
@@ -103,5 +103,13 @@ that meets the initial requirements of the semantic analyzer. As a library for l
 analysis and source code parsing, it is recommended to use: [nom is a parser combinators library](https://github.com/rust-bakery/nom).
 
 AST displays the **Turing complete** programming language and contains all the necessary elements for this.
+
+## 🛋️ Examples
+
+- 🔎 There is the example implementation separate project [Toy Codegen](https://github.com/mrLSD/toy-codegen).
+The project uses the `SemanticStack` results and converts them into **Code Generation** logic. Which clearly shows the 
+possibilities of using the results of the `semantic-analyzer-rs` `SemanticStackContext` results. LLVM is used as a 
+backend, [inkwell](https://github.com/TheDan64/inkwell) as a library for LLVM codegen, and compiled into an executable 
+program. The source of data is the AST structure itself.
 
 ## MIT [LICENSE](LICENSE)

--- a/README.md
+++ b/README.md
@@ -11,46 +11,46 @@
 Semantic analyzer is an open source semantic analyzer for programming languages 
 that makes it easy to build your own efficient compilers.
 
-## What is the library for and what tasks does it solve
+## 🌀 What is the library for and what tasks does it solve
 
 Creating a compilers for a programming language is process that involves several key 
 stages. Most commonly it is:
 
-- **Lexical Analysis (Lexer)**: This stage involves breaking down the input stream 
+▶️ **Lexical Analysis (Lexer)**: This stage involves breaking down the input stream 
 of characters into a series of tokens. Tokens are the atomic elements of the programming language, such as identifiers, keywords, operators, etc.
 
-- **Syntax Analysis (Parsing)**: At this stage, the tokens obtained in the previous 
+▶️ **Syntax Analysis (Parsing)**: At this stage, the tokens obtained in the previous 
 stage are grouped according to the grammar rules of the programming language. The result 
 of this process is an **Abstract Syntax Tree (AST)**, which represents a hierarchical structure of the code.
 
-- **Semantic Analysis**: This stage involves checking the semantic correctness of the code. This can include 
+⏩ **Semantic Analysis**: This stage involves checking the semantic correctness of the code. This can include 
 type checking, scope verification of variables, etc.
 
-- **Intermediate Code Optimization**: At this stage, the compiler tries to improve the intermediate representation of the code to make it more efficient. 
+▶️ **Intermediate Code Optimization**: At this stage, the compiler tries to improve the intermediate representation of the code to make it more efficient. 
 This can include dead code elimination, expression simplification, etc.
 
-- **Code Generation**: This is the final stage where the compiler transforms the optimized intermediate representation (IR) into 
+▶️ **Code Generation**: This is the final stage where the compiler transforms the optimized intermediate representation (IR) into 
 machine code specific to the target architecture.
 
 This library represent **Semantic Analysis** stage.
 
-### Features
+### 🌻 Features
 
-- **Name Binding and Scope Checking**: The analyzer verifies that all variables, constants, functions are declared before they're used, 
+✅ **Name Binding and Scope Checking**: The analyzer verifies that all variables, constants, functions are declared before they're used, 
 and that they're used within their scope. It also checks for name collisions, where variables, constants, functions, types in the same scope have the same name.
 
-- **Checking Function Calls**: The analyzer verifies that functions are called with the number of parameters and that the type of 
+✅ **Checking Function Calls**: The analyzer verifies that functions are called with the number of parameters and that the type of 
 arguments matches the type expected by the function.
 
-- **Scope Rules**: Checks that variables, functions, constants, types are used within their scope, and available in the visibility scope.
+✅ **Scope Rules**: Checks that variables, functions, constants, types are used within their scope, and available in the visibility scope.
 
-- **Type Checking**: The analyzer checks that operations are performed on compatible types for expressions, functions, constant, bindings.
+✅ **Type Checking**: The analyzer checks that operations are performed on compatible types for expressions, functions, constant, bindings.
 For operations in expressions. It is the process of verifying that the types of expressions are consistent with their usage in the context.
 
-- **Flow Control Checking**: The analyzer checks that the control flow statements (if-else, loop, return, break, continue) are used correctly. 
+✅ **Flow Control Checking**: The analyzer checks that the control flow statements (if-else, loop, return, break, continue) are used correctly. 
 Supported condition expressions and condition expression correctness check.
 
-- **Building the Symbol Table**: For analyzing used the symbol table as data structure used by the semantic analyzer to keep track of 
+✅ **Building the Symbol Table**: For analyzing used the symbol table as data structure used by the semantic analyzer to keep track of 
 symbols (variables, functions, constants) in the source code. Each entry in the symbol table contains the symbol's name, type, and scope related for block state, and other relevant information.
 
 ### 🌳 Semantic State Tree
@@ -106,7 +106,7 @@ AST displays the **Turing complete** programming language and contains all the n
 
 ## 🛋️ Examples
 
-- 🔎 There is the example implementation separate project [Toy Codegen](https://github.com/mrLSD/toy-codegen).
+- 🔎 There is the example implementation separate project [💾 Toy Codegen](https://github.com/mrLSD/toy-codegen).
 The project uses the `SemanticStack` results and converts them into **Code Generation** logic. Which clearly shows the 
 possibilities of using the results of the `semantic-analyzer-rs` `SemanticStackContext` results. LLVM is used as a 
 backend, [inkwell](https://github.com/TheDan64/inkwell) as a library for LLVM codegen, and compiled into an executable 

--- a/src/semantic.rs
+++ b/src/semantic.rs
@@ -562,7 +562,7 @@ impl State {
         let right_res = self.expression(right_expr, function_body_state);
 
         // If some of the `left` or `right` expression is empty just return with error in the state
-        let (Some(left_res), Some(right_res)) = (left_res, right_res) else {
+        let (Some(left_res), Some(right_res)) = (left_res.clone(), right_res.clone()) else {
             self.add_error(error::StateErrorResult::new(
                 error::StateErrorKind::ConditionIsEmpty,
                 format!("left={left_res:?}, right={right_res:?}"),
@@ -595,6 +595,7 @@ impl State {
         // Increment register
         function_body_state.borrow_mut().inc_register();
 
+        let register_number = function_body_state.borrow_mut().last_register_number;
         // Codegen for left condition and set result to register
         function_body_state
             .borrow_mut()
@@ -603,7 +604,7 @@ impl State {
                 left_res,
                 right_res,
                 data.left.condition.clone().into(),
-                function_body_state.borrow_mut().last_register_number,
+                register_number,
             );
 
         // Analyze right condition
@@ -615,6 +616,7 @@ impl State {
             // Increment register
             function_body_state.borrow_mut().inc_register();
 
+            let register_number = function_body_state.borrow_mut().last_register_number;
             // Stategen for logical condition for: left [LOGIC-OP] right
             // The result generated from registers, and stored to
             // new register
@@ -622,7 +624,7 @@ impl State {
                 right.0.clone().into(),
                 left_register_result,
                 right_register_result,
-                function_body_state.borrow_mut().last_register_number,
+                register_number,
             );
         }
         function_body_state.borrow_mut().last_register_number

--- a/src/types/error.rs
+++ b/src/types/error.rs
@@ -26,6 +26,7 @@ pub enum StateErrorKind {
     TypeNotFound,
     WrongReturnType,
     ConditionExpressionWrongType,
+    ConditionIsEmpty,
     ConditionExpressionNotSupported,
     ForbiddenCodeAfterReturnDeprecated,
     ForbiddenCodeAfterContinueDeprecated,

--- a/src/types/semantic.rs
+++ b/src/types/semantic.rs
@@ -30,18 +30,28 @@ impl SemanticStack {
     }
 
     /// Push Context to the stack as expression value data
-    pub fn expression_value(&mut self, expression: Value) {
-        self.push(SemanticStackContext::ExpressionValue { expression });
+    pub fn expression_value(&mut self, expression: Value, register_number: u64) {
+        self.push(SemanticStackContext::ExpressionValue {
+            expression,
+            register_number,
+        });
     }
 
     /// Push Context to the stack as expression const data
-    pub fn expression_const(&mut self, expression: Constant) {
-        self.push(SemanticStackContext::ExpressionConst { expression });
+    pub fn expression_const(&mut self, expression: Constant, register_number: u64) {
+        self.push(SemanticStackContext::ExpressionConst {
+            expression,
+            register_number,
+        });
     }
 
     /// Push Context to the stack as expression struct value data
-    pub fn expression_struct_value(&mut self, expression: Value, index: u32) {
-        self.push(SemanticStackContext::ExpressionStructValue { expression, index });
+    pub fn expression_struct_value(&mut self, expression: Value, index: u32, register_number: u64) {
+        self.push(SemanticStackContext::ExpressionStructValue {
+            expression,
+            index,
+            register_number,
+        });
     }
 
     /// Push Context to the stack as expression operation data
@@ -50,17 +60,23 @@ impl SemanticStack {
         operation: ExpressionOperations,
         left_value: ExpressionResult,
         right_value: ExpressionResult,
+        register_number: u64,
     ) {
         self.push(SemanticStackContext::ExpressionOperation {
             operation,
             left_value,
             right_value,
+            register_number,
         });
     }
 
     /// Push Context to the stack as function call data
-    pub fn call(&mut self, call: Function, params: Vec<ExpressionResult>) {
-        self.push(SemanticStackContext::Call { call, params });
+    pub fn call(&mut self, call: Function, params: Vec<ExpressionResult>, register_number: u64) {
+        self.push(SemanticStackContext::Call {
+            call,
+            params,
+            register_number,
+        });
     }
 
     /// Push Context to the stack as let-binding data
@@ -164,22 +180,27 @@ impl SemanticStack {
 pub enum SemanticStackContext {
     ExpressionValue {
         expression: Value,
+        register_number: u64,
     },
     ExpressionConst {
         expression: Constant,
+        register_number: u64,
     },
     ExpressionStructValue {
         expression: Value,
         index: u32,
+        register_number: u64,
     },
     ExpressionOperation {
         operation: ExpressionOperations,
         left_value: ExpressionResult,
         right_value: ExpressionResult,
+        register_number: u64,
     },
     Call {
         call: Function,
         params: Vec<ExpressionResult>,
+        register_number: u64,
     },
     LetBinding {
         let_decl: Value,

--- a/src/types/semantic.rs
+++ b/src/types/semantic.rs
@@ -9,7 +9,7 @@ use super::types::StructTypes;
 use super::{Constant, Function, FunctionStatement, LabelName, Value};
 
 /// # Semantic stack
-/// Semantic stack represent stack of Semantic Context
+/// Semantic stack represent stack of Semantic Context results
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct SemanticStack(Vec<SemanticStackContext>);
 
@@ -29,7 +29,11 @@ impl SemanticStack {
         self.0
     }
 
-    /// Push Context to the stack as expression value data
+    /// Push Context to the stack as expression value data.
+    ///
+    /// ## Parameters
+    /// - `expression` - contains expression value
+    /// - `register_number` - register to store result data
     pub fn expression_value(&mut self, expression: Value, register_number: u64) {
         self.push(SemanticStackContext::ExpressionValue {
             expression,
@@ -37,7 +41,11 @@ impl SemanticStack {
         });
     }
 
-    /// Push Context to the stack as expression const data
+    /// Push Context to the stack as expression const data.
+    ///
+    /// ## Parameters
+    /// - `expression` - contains expression constant
+    /// - `register_number` - register to store result data
     pub fn expression_const(&mut self, expression: Constant, register_number: u64) {
         self.push(SemanticStackContext::ExpressionConst {
             expression,
@@ -45,7 +53,12 @@ impl SemanticStack {
         });
     }
 
-    /// Push Context to the stack as expression struct value data
+    /// Push Context to the stack as expression struct value data.
+    ///
+    /// ## Parameters
+    /// - `expression` - contains expression value for specific `Structure` attribute
+    /// - `index` - represent attribute index in the `Structure` type
+    /// - `register_number` - register to store result data
     pub fn expression_struct_value(&mut self, expression: Value, index: u32, register_number: u64) {
         self.push(SemanticStackContext::ExpressionStructValue {
             expression,
@@ -54,7 +67,15 @@ impl SemanticStack {
         });
     }
 
-    /// Push Context to the stack as expression operation data
+    /// Push Context to the stack as expression operation data.
+    /// `expression_operation` imply operation between `left_value` and
+    /// `right_value` and store result to `register_number`.
+    ///
+    /// ## Parameters
+    /// - `operation` - specific operation
+    /// - `left_value` - left expression result
+    /// - `right_value` - right expression result
+    /// - `register_number` - register to store result of expression operation
     pub fn expression_operation(
         &mut self,
         operation: ExpressionOperations,
@@ -71,6 +92,7 @@ impl SemanticStack {
     }
 
     /// Push Context to the stack as function call data
+    /// ## Parameters
     pub fn call(&mut self, call: Function, params: Vec<ExpressionResult>, register_number: u64) {
         self.push(SemanticStackContext::Call {
             call,
@@ -80,6 +102,7 @@ impl SemanticStack {
     }
 
     /// Push Context to the stack as let-binding data
+    /// ## Parameters
     pub fn let_binding(&mut self, let_decl: Value, expr_result: ExpressionResult) {
         self.push(SemanticStackContext::LetBinding {
             let_decl,
@@ -88,46 +111,55 @@ impl SemanticStack {
     }
 
     /// Push Context to the stack as binding data
+    /// ## Parameters
     pub fn binding(&mut self, val: Value, expr_result: ExpressionResult) {
         self.push(SemanticStackContext::Binding { val, expr_result });
     }
 
     /// Push Context to the stack as function declaration data
+    /// ## Parameters
     pub fn function_declaration(&mut self, fn_decl: FunctionStatement) {
         self.push(SemanticStackContext::FunctionDeclaration { fn_decl });
     }
 
     /// Push Context to the stack as constant data
+    /// ## Parameters
     pub fn constant(&mut self, const_decl: Constant) {
         self.push(SemanticStackContext::Constant { const_decl });
     }
 
     /// Push Context to the stack as types data
+    /// ## Parameters
     pub fn types(&mut self, type_decl: StructTypes) {
         self.push(SemanticStackContext::Types { type_decl });
     }
 
     /// Push Context to the stack as expression function return data
+    /// ## Parameters
     pub fn expression_function_return(&mut self, expr_result: ExpressionResult) {
         self.push(SemanticStackContext::ExpressionFunctionReturn { expr_result });
     }
 
     /// Push Context to the stack as `expression function return with label` data
+    /// ## Parameters
     pub fn expression_function_return_with_label(&mut self, expr_result: ExpressionResult) {
         self.push(SemanticStackContext::ExpressionFunctionReturnWithLabel { expr_result });
     }
 
     /// Push Context to the stack as `set label` data
+    /// ## Parameters
     pub fn set_label(&mut self, label: LabelName) {
         self.push(SemanticStackContext::SetLabel { label });
     }
 
     /// Push Context to the stack as `jump to` data
+    /// ## Parameters
     pub fn jump_to(&mut self, label: LabelName) {
         self.push(SemanticStackContext::JumpTo { label });
     }
 
     /// Push Context to the stack as `if condition expression` data
+    /// ## Parameters
     pub fn if_condition_expression(
         &mut self,
         expr_result: ExpressionResult,
@@ -142,34 +174,74 @@ impl SemanticStack {
     }
 
     /// Push Context to the stack as `condition expression` data
+    /// ## Parameters
     pub fn condition_expression(
         &mut self,
         left_result: ExpressionResult,
         right_result: ExpressionResult,
         condition: Condition,
+        register_number: u64,
     ) {
         self.push(SemanticStackContext::ConditionExpression {
             left_result,
             right_result,
             condition,
+            register_number,
         });
     }
 
     /// Push Context to the stack as `jump function return` data
+    /// ## Parameters
     pub fn jump_function_return(&mut self, expr_result: ExpressionResult) {
         self.push(SemanticStackContext::JumpFunctionReturn { expr_result });
     }
 
-    /// Push Context to the stack as `logic condition` data
-    pub fn logic_condition(&mut self, logic_condition: LogicCondition) {
-        self.push(SemanticStackContext::LogicCondition { logic_condition });
+    /// Push Context to the stack as `logic condition` data.
+    /// Operate with registers:
+    ///
+    /// ## Parameters
+    /// - left_register_result - result of left condition
+    /// - right_register_result - result of right condition
+    /// - register_number - register to store instruction result
+    pub fn logic_condition(
+        &mut self,
+        logic_condition: LogicCondition,
+        left_register_result: u64,
+        right_register_result: u64,
+        register_number: u64,
+    ) {
+        self.push(SemanticStackContext::LogicCondition {
+            logic_condition,
+            left_register_result,
+            right_register_result,
+            register_number,
+        });
     }
 
-    /// Push Context to the stack as `if condition logic` data
-    pub fn if_condition_logic(&mut self, label_if_begin: LabelName, label_if_end: LabelName) {
+    /// Push Context to the stack as `if condition logic` data.
+    /// `if_condition_logic` instruction read data from `result_register`
+    /// and conditionally jump: if "true' to `label_if_begin` or
+    /// `label_if_end` if "false" (data contained as result after
+    /// reading `result_register`).
+    ///
+    /// ## Parameters
+    /// - `label_if_begin` - label for a jump if `result_register` contains
+    /// result with "true"
+    /// - `label_if_end` - label for a jump if `result_register` contains
+    ///  result with "false". It can be not only `if_end` but any kind (for
+    /// example `if_else`)
+    /// - `result_register` - contains register of previous condition logic
+    /// calculations.
+    pub fn if_condition_logic(
+        &mut self,
+        label_if_begin: LabelName,
+        label_if_end: LabelName,
+        result_register: u64,
+    ) {
         self.push(SemanticStackContext::IfConditionLogic {
             label_if_begin,
             label_if_end,
+            result_register,
         });
     }
 }
@@ -240,15 +312,20 @@ pub enum SemanticStackContext {
         left_result: ExpressionResult,
         right_result: ExpressionResult,
         condition: Condition,
+        register_number: u64,
     },
     JumpFunctionReturn {
         expr_result: ExpressionResult,
     },
     LogicCondition {
         logic_condition: LogicCondition,
+        left_register_result: u64,
+        right_register_result: u64,
+        register_number: u64,
     },
     IfConditionLogic {
         label_if_begin: LabelName,
         label_if_end: LabelName,
+        result_register: u64,
     },
 }

--- a/tests/expressions_tests.rs
+++ b/tests/expressions_tests.rs
@@ -357,6 +357,22 @@ fn expression_ast_transform_primitive_struct_value() {
 }
 
 #[test]
+fn expression_ast_transform_expression() {
+    let val = ast::PrimitiveValue::Ptr;
+    let sub_expr = ast::Expression {
+        expression_value: ast::ExpressionValue::PrimitiveValue(val),
+        operation: None,
+    };
+    let expr: Expression = ast::Expression {
+        expression_value: ast::ExpressionValue::Expression(Box::new(sub_expr)),
+        operation: None,
+    }
+    .into();
+    format!("{expr:#?}");
+    assert_eq!(expr.to_string(), "ptr");
+}
+
+#[test]
 fn expression_value_name_not_found() {
     let block_state = Rc::new(RefCell::new(BlockState::new(None)));
     let mut t = SemanticTest::new();

--- a/tests/expressions_tests.rs
+++ b/tests/expressions_tests.rs
@@ -27,6 +27,7 @@ fn set_result_type(
     left: u64,
     reg_right: bool,
     right: u64,
+    register_number: u64,
 ) -> SemanticStackContext {
     let left_val = if reg_left {
         ExpressionResultValue::Register(left)
@@ -48,6 +49,7 @@ fn set_result_type(
             expr_type: Type::Primitive(PrimitiveTypes::U16),
             expr_value: right_val,
         },
+        register_number,
     }
 }
 
@@ -404,7 +406,10 @@ fn expression_value_name_exists() {
     assert_eq!(state.len(), 1);
     assert_eq!(
         state[0],
-        SemanticStackContext::ExpressionValue { expression: value }
+        SemanticStackContext::ExpressionValue {
+            expression: value,
+            register_number: 1
+        }
     );
     assert!(t.is_empty_error());
 }
@@ -437,7 +442,10 @@ fn expression_const_exists() {
     assert_eq!(state.len(), 1);
     assert_eq!(
         state[0],
-        SemanticStackContext::ExpressionConst { expression: value }
+        SemanticStackContext::ExpressionConst {
+            expression: value,
+            register_number: 1
+        }
     );
     assert!(t.is_empty_error());
 }
@@ -768,7 +776,7 @@ fn expression_struct_value() {
     assert!(t.is_empty_error());
     let res = t.state.expression(&expr, &block_state).unwrap();
     assert!(t.is_empty_error());
-    assert_eq!(res.expr_value, ExpressionResultValue::Register(1));
+    assert_eq!(res.expr_value, ExpressionResultValue::Register(2));
     assert_eq!(res.expr_type, Type::Primitive(PrimitiveTypes::Bool));
     let state = block_state.borrow().context.clone().get();
     assert_eq!(state.len(), 1);
@@ -776,7 +784,8 @@ fn expression_struct_value() {
         state[0],
         SemanticStackContext::ExpressionStructValue {
             expression: value,
-            index: 0
+            index: 0,
+            register_number: 1
         }
     );
 }
@@ -824,7 +833,7 @@ fn expression_func_call() {
     assert_eq!(
         res,
         ExpressionResult {
-            expr_value: ExpressionResultValue::Register(1),
+            expr_value: ExpressionResultValue::Register(2),
             expr_type: Type::Primitive(PrimitiveTypes::Ptr)
         }
     );
@@ -839,6 +848,7 @@ fn expression_func_call() {
                 parameters: vec![]
             },
             params: vec![],
+            register_number: 1
         }
     );
 }
@@ -903,6 +913,7 @@ fn expression_operation() {
                 expr_type: Type::Primitive(PrimitiveTypes::Char),
                 expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::Char('b'))
             },
+            register_number: 1
         }
     );
 }
@@ -974,11 +985,11 @@ fn expression_multiple_operation1() {
     assert_eq!(res.expr_value, ExpressionResultValue::Register(5));
     let state = block_state.borrow().context.clone().get();
     assert_eq!(state.len(), 5);
-    assert_eq!(state[0], set_result_type(Plus, false, 1, false, 2));
-    assert_eq!(state[1], set_result_type(Multiply, true, 1, false, 3));
-    assert_eq!(state[2], set_result_type(Minus, true, 2, false, 4));
-    assert_eq!(state[3], set_result_type(Multiply, false, 5, false, 6));
-    assert_eq!(state[4], set_result_type(Minus, true, 3, true, 4));
+    assert_eq!(state[0], set_result_type(Plus, false, 1, false, 2, 1));
+    assert_eq!(state[1], set_result_type(Multiply, true, 1, false, 3, 2));
+    assert_eq!(state[2], set_result_type(Minus, true, 2, false, 4, 3));
+    assert_eq!(state[3], set_result_type(Multiply, false, 5, false, 6, 4));
+    assert_eq!(state[4], set_result_type(Minus, true, 3, true, 4, 5));
     assert!(t.is_empty_error());
 }
 
@@ -1034,11 +1045,11 @@ fn expression_multiple_operation2() {
     assert_eq!(res.expr_value, ExpressionResultValue::Register(5));
     let state = block_state.borrow().context.clone().get();
     assert_eq!(state.len(), 5);
-    assert_eq!(state[0], set_result_type(Plus, false, 100, false, 2));
-    assert_eq!(state[1], set_result_type(Minus, false, 3, false, 4));
-    assert_eq!(state[2], set_result_type(Multiply, false, 5, false, 6));
-    assert_eq!(state[3], set_result_type(Minus, true, 2, true, 3));
-    assert_eq!(state[4], set_result_type(Multiply, true, 1, true, 4));
+    assert_eq!(state[0], set_result_type(Plus, false, 100, false, 2, 1));
+    assert_eq!(state[1], set_result_type(Minus, false, 3, false, 4, 2));
+    assert_eq!(state[2], set_result_type(Multiply, false, 5, false, 6, 3));
+    assert_eq!(state[3], set_result_type(Minus, true, 2, true, 3, 4));
+    assert_eq!(state[4], set_result_type(Multiply, true, 1, true, 4, 5));
     assert!(t.is_empty_error());
 }
 
@@ -1067,8 +1078,8 @@ fn expression_multiple_operation_simple1() {
     assert_eq!(res.expr_value, ExpressionResultValue::Register(2));
     let state = block_state.borrow().context.clone().get();
     assert_eq!(state.len(), 2);
-    assert_eq!(state[0], set_result_type(Multiply, false, 5, false, 6));
-    assert_eq!(state[1], set_result_type(Minus, false, 100, true, 1));
+    assert_eq!(state[0], set_result_type(Multiply, false, 5, false, 6, 1));
+    assert_eq!(state[1], set_result_type(Minus, false, 100, true, 1, 2));
     assert!(t.is_empty_error());
 }
 
@@ -1094,8 +1105,8 @@ fn expression_multiple_operation_simple2() {
     assert_eq!(res.expr_value, ExpressionResultValue::Register(2));
     let state = block_state.borrow().context.clone().get();
     assert_eq!(state.len(), 2);
-    assert_eq!(state[0], set_result_type(Multiply, false, 20, false, 5));
-    assert_eq!(state[1], set_result_type(Minus, true, 1, false, 40));
+    assert_eq!(state[0], set_result_type(Multiply, false, 20, false, 5, 1));
+    assert_eq!(state[1], set_result_type(Minus, true, 1, false, 40, 2));
     assert!(t.is_empty_error());
 }
 
@@ -1125,9 +1136,9 @@ fn expression_multiple_operation_simple3() {
     assert_eq!(res.expr_value, ExpressionResultValue::Register(3));
     let state = block_state.borrow().context.clone().get();
     assert_eq!(state.len(), 3);
-    assert_eq!(state[0], set_result_type(Multiply, false, 20, false, 4));
-    assert_eq!(state[1], set_result_type(Minus, true, 1, false, 40));
-    assert_eq!(state[2], set_result_type(Minus, true, 2, false, 5));
+    assert_eq!(state[0], set_result_type(Multiply, false, 20, false, 4, 1));
+    assert_eq!(state[1], set_result_type(Minus, true, 1, false, 40, 2));
+    assert_eq!(state[2], set_result_type(Minus, true, 2, false, 5, 3));
     assert!(t.is_empty_error());
 }
 
@@ -1161,8 +1172,8 @@ fn expression_multiple_operation_simple4() {
     assert_eq!(res.expr_value, ExpressionResultValue::Register(3));
     let state = block_state.borrow().context.clone().get();
     assert_eq!(state.len(), 3);
-    assert_eq!(state[0], set_result_type(Multiply, false, 5, false, 6));
-    assert_eq!(state[1], set_result_type(Minus, false, 100, true, 1));
-    assert_eq!(state[2], set_result_type(Minus, true, 2, false, 15));
+    assert_eq!(state[0], set_result_type(Multiply, false, 5, false, 6, 1));
+    assert_eq!(state[1], set_result_type(Minus, false, 100, true, 1, 2));
+    assert_eq!(state[2], set_result_type(Minus, true, 2, false, 15, 3));
     assert!(t.is_empty_error());
 }

--- a/tests/if_tests.rs
+++ b/tests/if_tests.rs
@@ -489,33 +489,88 @@ fn if_condition_calculation_logic() {
                 expr_type: Type::Primitive(PrimitiveTypes::I8),
                 expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::I8(6))
             },
-            condition: Condition::Eq
+            condition: Condition::Eq,
+            register_number: 1,
         }
     );
     assert_eq!(
         ctx[1],
         SemanticStackContext::IfConditionLogic {
             label_if_begin: label_if_begin.clone(),
-            label_if_end
+            label_if_end: label_if_end.clone(),
+            result_register: 1
         }
     );
-    assert_eq!(ctx[2], ctx[0]);
+    assert_eq!(
+        ctx[2],
+        SemanticStackContext::ConditionExpression {
+            left_result: ExpressionResult {
+                expr_type: Type::Primitive(PrimitiveTypes::I8),
+                expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::I8(3))
+            },
+            right_result: ExpressionResult {
+                expr_type: Type::Primitive(PrimitiveTypes::I8),
+                expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::I8(6))
+            },
+            condition: Condition::Eq,
+            register_number: 2,
+        }
+    );
     assert_eq!(
         ctx[3],
         SemanticStackContext::IfConditionLogic {
-            label_if_begin,
-            label_if_end: label_if_else
+            label_if_begin: label_if_begin.clone(),
+            label_if_end: label_if_else,
+            result_register: 2
         }
     );
-    assert_eq!(ctx[4], ctx[0]);
-    assert_eq!(ctx[5], ctx[0]);
+    assert_eq!(
+        ctx[4],
+        SemanticStackContext::ConditionExpression {
+            left_result: ExpressionResult {
+                expr_type: Type::Primitive(PrimitiveTypes::I8),
+                expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::I8(3))
+            },
+            right_result: ExpressionResult {
+                expr_type: Type::Primitive(PrimitiveTypes::I8),
+                expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::I8(6))
+            },
+            condition: Condition::Eq,
+            register_number: 3,
+        }
+    );
+    assert_eq!(
+        ctx[5],
+        SemanticStackContext::ConditionExpression {
+            left_result: ExpressionResult {
+                expr_type: Type::Primitive(PrimitiveTypes::I8),
+                expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::I8(3))
+            },
+            right_result: ExpressionResult {
+                expr_type: Type::Primitive(PrimitiveTypes::I8),
+                expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::I8(6))
+            },
+            condition: Condition::Eq,
+            register_number: 4,
+        }
+    );
     assert_eq!(
         ctx[6],
         SemanticStackContext::LogicCondition {
-            logic_condition: LogicCondition::Or
+            logic_condition: LogicCondition::Or,
+            left_register_result: 3,
+            right_register_result: 4,
+            register_number: 5
         }
     );
-    assert_eq!(ctx[7], ctx[1]);
+    assert_eq!(
+        ctx[7],
+        SemanticStackContext::IfConditionLogic {
+            label_if_begin,
+            label_if_end,
+            result_register: 5
+        }
+    );
     assert_eq!(ctx.len(), 8);
     assert!(t.is_empty_error());
 }
@@ -557,11 +612,16 @@ fn if_condition_when_left_expr_return_error() {
         &label_if_end,
         false,
     );
-    assert!(t.check_errors_len(1), "Errors: {:?}", t.state.errors.len());
+    assert!(t.check_errors_len(2), "Errors: {:?}", t.state.errors.len());
     assert!(
-        t.check_error(StateErrorKind::FunctionNotFound),
+        t.check_error_index(0, StateErrorKind::FunctionNotFound),
         "Errors: {:?}",
         t.state.errors[0]
+    );
+    assert!(
+        t.check_error_index(1, StateErrorKind::ConditionIsEmpty),
+        "Errors: {:?}",
+        t.state.errors[1]
     );
 }
 

--- a/tests/if_tests.rs
+++ b/tests/if_tests.rs
@@ -983,6 +983,7 @@ fn if_body_statements() {
                 parameters: vec![],
             },
             params: vec![],
+            register_number: 1
         }
     );
     assert_eq!(
@@ -1033,6 +1034,7 @@ fn if_body_statements() {
                 parameters: vec![],
             },
             params: vec![],
+            register_number: 2
         }
     );
     assert_eq!(
@@ -1070,6 +1072,7 @@ fn if_body_statements() {
                 parameters: vec![],
             },
             params: vec![],
+            register_number: 3
         }
     );
     assert_eq!(
@@ -1257,6 +1260,7 @@ fn if_loop_body_statements() {
                 parameters: vec![],
             },
             params: vec![],
+            register_number: 1
         }
     );
     assert_eq!(
@@ -1307,6 +1311,7 @@ fn if_loop_body_statements() {
                 parameters: vec![],
             },
             params: vec![],
+            register_number: 2
         }
     );
     assert_eq!(
@@ -1343,6 +1348,7 @@ fn if_loop_body_statements() {
                 parameters: vec![],
             },
             params: vec![],
+            register_number: 3
         }
     );
     assert_eq!(

--- a/tests/loop_tests.rs
+++ b/tests/loop_tests.rs
@@ -63,6 +63,8 @@ fn loop_transform() {
     format!("{loop_stmts:#?}");
     for loop_stmt in loop_stmts {
         let loop_stmt_into: LoopBodyStatement = loop_stmt.into();
+        // For grcov
+        format!("{loop_stmt_into:#?}");
         match loop_stmt_into {
             LoopBodyStatement::LetBinding(val) => assert_eq!(val, let_binding.clone().into()),
             LoopBodyStatement::Binding(val) => assert_eq!(val, binding.clone().into()),

--- a/tests/loop_tests.rs
+++ b/tests/loop_tests.rs
@@ -214,6 +214,7 @@ fn loop_statements() {
                 parameters: vec![],
             },
             params: vec![],
+            register_number: 1,
         }
     );
     assert_eq!(
@@ -261,6 +262,7 @@ fn loop_statements() {
                 parameters: vec![],
             },
             params: vec![],
+            register_number: 2
         }
     );
     assert_eq!(
@@ -303,6 +305,7 @@ fn loop_statements() {
                 parameters: vec![],
             },
             params: vec![],
+            register_number: 3
         }
     );
     assert_eq!(

--- a/tests/main_tests.rs
+++ b/tests/main_tests.rs
@@ -193,6 +193,7 @@ fn main_run() {
                 parameters: vec![],
             },
             params: vec![],
+            register_number: 1
         }
     );
 
@@ -247,6 +248,7 @@ fn main_run() {
                 parameters: vec![],
             },
             params: vec![],
+            register_number: 2
         }
     );
     assert_eq!(
@@ -285,6 +287,7 @@ fn main_run() {
                 parameters: vec![],
             },
             params: vec![],
+            register_number: 3
         }
     );
     assert_eq!(
@@ -349,7 +352,6 @@ fn double_return() {
     let fn_stm = ast::MainStatement::Function(fn1);
     let main_stm: ast::Main = vec![fn_stm];
     t.state.run(&main_stm);
-    println!("{:#?}", t.state.errors);
     assert!(t.check_errors_len(2), "Errors: {:?}", t.state.errors.len());
     assert!(t.check_error_index(0, StateErrorKind::ForbiddenCodeAfterReturnDeprecated));
     assert!(t.check_error_index(1, StateErrorKind::ReturnAlreadyCalled));

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -35,7 +35,7 @@ impl SemanticTest {
 
     #[allow(dead_code)]
     pub fn check_error(&self, err_kind: StateErrorKind) -> bool {
-        self.state.errors.get(0).unwrap().kind == err_kind
+        self.state.errors.first().unwrap().kind == err_kind
     }
 
     #[allow(dead_code)]


### PR DESCRIPTION
## Description

### 🥇 Registers

Implemented register numbers for expressions and assignment operations.

The main point is to track correct expressions, values, and function parameters.

- [x] issue #13

### 🥈 Toy Codegen

As an example of usage for `semantic-alalyzer-rs` is implemented as a separate project [toy-codegen](https://github.com/mrLSD/toy-codegen). It shows how to use `SemanticStack` for Codegen generation. Added to [README.md](README.md).

### 📝  Documentation

- [x] Extended README docs
- [x] Extended code documentation for `SemanticStack` functions generator.