### PR TITLE
Feat:  flatten tree BlockState for SemanticStackContext

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-analyzer"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Evgeny Ukhanov <mrlsd@ya.ru>"]
 description = "Semantic analyzer library for compilers written in Rust for semantic analysis of programming languages AST"
 keywords = ["compiler", "semantic-analisis", "semantic-alalyzer", "compiler-design", "semantic"]

--- a/src/semantic.rs
+++ b/src/semantic.rs
@@ -15,7 +15,7 @@ use crate::types::block_state::BlockState;
 use crate::types::expression::{
     Expression, ExpressionResult, ExpressionResultValue, ExpressionStructValue,
 };
-use crate::types::semantic::{SemanticContext, SemanticStack};
+use crate::types::semantic::{GlobalSemanticContext, SemanticContext, SemanticStack};
 use crate::types::types::{Type, TypeName};
 use crate::types::{
     error, Binding, Constant, ConstantName, Function, FunctionCall, FunctionName,
@@ -349,13 +349,9 @@ impl State {
                             // previous returns and invoke return instruction itself.
                             body_state
                                 .borrow_mut()
-                                .context
                                 .expression_function_return_with_label(res);
                         } else {
-                            body_state
-                                .borrow_mut()
-                                .context
-                                .expression_function_return(res);
+                            body_state.borrow_mut().expression_function_return(res);
                         }
                     }
                 }
@@ -441,10 +437,7 @@ impl State {
             .borrow_mut()
             .set_inner_value_name(&inner_name);
 
-        function_state
-            .borrow_mut()
-            .context
-            .let_binding(value, expr_result);
+        function_state.borrow_mut().let_binding(value, expr_result);
     }
 
     /// # Binding statement
@@ -481,10 +474,7 @@ impl State {
             ));
             return;
         }
-        function_state
-            .borrow_mut()
-            .context
-            .binding(value, expr_result);
+        function_state.borrow_mut().binding(value, expr_result);
     }
 
     /// # Function-call
@@ -539,7 +529,6 @@ impl State {
         // Store always result to register even for void result
         body_state
             .borrow_mut()
-            .context
             .call(func_data, params, last_register_number);
         Some(fn_type)
     }
@@ -597,15 +586,12 @@ impl State {
 
         let register_number = function_body_state.borrow_mut().last_register_number;
         // Codegen for left condition and set result to register
-        function_body_state
-            .borrow_mut()
-            .context
-            .condition_expression(
-                left_res,
-                right_res,
-                data.left.condition.clone().into(),
-                register_number,
-            );
+        function_body_state.borrow_mut().condition_expression(
+            left_res,
+            right_res,
+            data.left.condition.clone().into(),
+            register_number,
+        );
 
         // Analyze right condition
         if let Some(right) = &data.right {
@@ -620,7 +606,7 @@ impl State {
             // Stategen for logical condition for: left [LOGIC-OP] right
             // The result generated from registers, and stored to
             // new register
-            function_body_state.borrow_mut().context.logic_condition(
+            function_body_state.borrow_mut().logic_condition(
                 right.0.clone().into(),
                 left_register_result,
                 right_register_result,
@@ -679,7 +665,7 @@ impl State {
                         // Jump to return label in codegen and set return
                         // status to indicate function, that it's manual
                         // return
-                        if_body_state.borrow_mut().context.jump_function_return(res);
+                        if_body_state.borrow_mut().jump_function_return(res);
                         if_body_state.borrow_mut().set_return();
                         return_is_called = true;
                     };
@@ -755,7 +741,7 @@ impl State {
                         // Jump to return label in codegen and set return
                         // status to indicate function, that it's manual
                         // return
-                        if_body_state.borrow_mut().context.jump_function_return(res);
+                        if_body_state.borrow_mut().jump_function_return(res);
                         if_body_state.borrow_mut().set_return();
                         return_is_called = true;
                     }
@@ -764,18 +750,12 @@ impl State {
                     continue_is_called = true;
                     // Skip next loop  step and jump to the start
                     // of loop
-                    if_body_state
-                        .borrow_mut()
-                        .context
-                        .jump_to(label_loop_start.clone());
+                    if_body_state.borrow_mut().jump_to(label_loop_start.clone());
                 }
                 ast::IfLoopBodyStatement::Break => {
                     break_is_called = true;
                     // Break loop and jump to the end of loop
-                    if_body_state
-                        .borrow_mut()
-                        .context
-                        .jump_to(label_loop_end.clone());
+                    if_body_state.borrow_mut().jump_to(label_loop_end.clone());
                 }
             }
         }
@@ -805,13 +785,13 @@ impl State {
 
                 // State for if-condition from expression and if-body start
                 if is_else {
-                    if_body_state.borrow_mut().context.if_condition_expression(
+                    if_body_state.borrow_mut().if_condition_expression(
                         expr_result,
                         label_if_begin.clone(),
                         label_if_else.clone(),
                     );
                 } else {
-                    if_body_state.borrow_mut().context.if_condition_expression(
+                    if_body_state.borrow_mut().if_condition_expression(
                         expr_result,
                         label_if_begin.clone(),
                         label_if_end.clone(),
@@ -824,13 +804,13 @@ impl State {
                 let result_register = self.condition_expression(expr_logic, if_body_state);
                 // State for if-condition-logic with if-body start
                 if is_else {
-                    if_body_state.borrow_mut().context.if_condition_logic(
+                    if_body_state.borrow_mut().if_condition_logic(
                         label_if_begin.clone(),
                         label_if_else.clone(),
                         result_register,
                     );
                 } else {
-                    if_body_state.borrow_mut().context.if_condition_logic(
+                    if_body_state.borrow_mut().if_condition_logic(
                         label_if_begin.clone(),
                         label_if_end.clone(),
                         result_register,
@@ -912,7 +892,7 @@ impl State {
 
         //== If condition main body
         // Set if-begin label
-        if_body_state.borrow_mut().context.set_label(label_if_begin);
+        if_body_state.borrow_mut().set_label(label_if_begin);
         // Analyze if-conditions body kind.
         // Return flag for current body state, excluding children return claims
         let return_is_called = match &data.body {
@@ -938,16 +918,13 @@ impl State {
         // Codegen for jump to if-end statement - return to program flow.
         // If return is set do not add jump-to-end label.
         if !return_is_called {
-            if_body_state
-                .borrow_mut()
-                .context
-                .jump_to(label_if_end.clone());
+            if_body_state.borrow_mut().jump_to(label_if_end.clone());
         }
 
         // Check else statements: else, else-if
         if is_else {
             // Set if-else label
-            if_body_state.borrow_mut().context.set_label(label_if_else);
+            if_body_state.borrow_mut().set_label(label_if_else);
 
             // Analyse if-else body: data.else_statement
             if let Some(else_body) = &data.else_statement {
@@ -981,10 +958,7 @@ impl State {
                 // Codegen for jump to if-end statement -return to program flow
                 // If return is set do not add jump-to-end label.
                 if !return_is_called {
-                    if_body_state
-                        .borrow_mut()
-                        .context
-                        .jump_to(label_if_end.clone());
+                    if_body_state.borrow_mut().jump_to(label_if_end.clone());
                 }
             } else if let Some(else_if_statement) = &data.else_if_statement {
                 // Analyse  else-if statement
@@ -1000,7 +974,7 @@ impl State {
 
         // End label for all if statement, should be set only once
         if !is_set_label_if_end {
-            if_body_state.borrow_mut().context.set_label(label_if_end);
+            if_body_state.borrow_mut().set_label(label_if_end);
         }
     }
 
@@ -1035,11 +1009,9 @@ impl State {
 
         loop_body_state
             .borrow_mut()
-            .context
             .jump_to(label_loop_begin.clone());
         loop_body_state
             .borrow_mut()
-            .context
             .set_label(label_loop_begin.clone());
 
         let mut return_is_called = false;
@@ -1093,20 +1065,14 @@ impl State {
                         // Jump to return label in codegen and set return
                         // status to indicate function, that it's manual
                         // return
-                        loop_body_state
-                            .borrow_mut()
-                            .context
-                            .jump_function_return(res);
+                        loop_body_state.borrow_mut().jump_function_return(res);
                         loop_body_state.borrow_mut().set_return();
                         return_is_called = true;
                     }
                 }
                 ast::LoopBodyStatement::Break => {
                     // Break loop and jump to the end of loop
-                    loop_body_state
-                        .borrow_mut()
-                        .context
-                        .jump_to(label_loop_end.clone());
+                    loop_body_state.borrow_mut().jump_to(label_loop_end.clone());
                     break_is_called = true;
                 }
                 ast::LoopBodyStatement::Continue => {
@@ -1114,7 +1080,6 @@ impl State {
                     // of loop
                     loop_body_state
                         .borrow_mut()
-                        .context
                         .jump_to(label_loop_begin.clone());
                     continue_is_called = true;
                 }
@@ -1126,14 +1091,10 @@ impl State {
             // Because it's loop jump to loop begin
             loop_body_state
                 .borrow_mut()
-                .context
                 .jump_to(label_loop_begin.clone());
 
             // Loop ending
-            loop_body_state
-                .borrow_mut()
-                .context
-                .set_label(label_loop_end);
+            loop_body_state.borrow_mut().set_label(label_loop_end);
         }
     }
 
@@ -1206,13 +1167,11 @@ impl State {
                 let ty = if let Some(val) = value_from_state {
                     body_state
                         .borrow_mut()
-                        .context
                         .expression_value(val.clone(), last_register_number);
                     val.inner_type
                 } else if let Some(const_val) = self.global.constants.get(&value.name().into()) {
                     body_state
                         .borrow_mut()
-                        .context
                         .expression_const(const_val.clone(), last_register_number);
                     const_val.constant_type.clone()
                 } else {
@@ -1309,7 +1268,7 @@ impl State {
                 // Register contains result
                 body_state.borrow_mut().inc_register();
                 let last_register_number = body_state.borrow().last_register_number;
-                body_state.borrow_mut().context.expression_struct_value(
+                body_state.borrow_mut().expression_struct_value(
                     val.clone(),
                     attributes.clone().attr_index,
                     last_register_number,
@@ -1343,7 +1302,7 @@ impl State {
             body_state.borrow_mut().inc_register();
             let last_register_number = body_state.borrow().last_register_number;
             // Call expression operation for: OP(left_value, right_value)
-            body_state.borrow_mut().context.expression_operation(
+            body_state.borrow_mut().expression_operation(
                 op.clone().into(),
                 left_value.clone(),
                 right_value.clone(),

--- a/src/semantic.rs
+++ b/src/semantic.rs
@@ -15,7 +15,7 @@ use crate::types::block_state::BlockState;
 use crate::types::expression::{
     Expression, ExpressionResult, ExpressionResultValue, ExpressionStructValue,
 };
-use crate::types::semantic::SemanticStack;
+use crate::types::semantic::{SemanticContext, SemanticStack};
 use crate::types::types::{Type, TypeName};
 use crate::types::{
     error, Binding, Constant, ConstantName, Function, FunctionCall, FunctionName,

--- a/src/types/block_state.rs
+++ b/src/types/block_state.rs
@@ -200,16 +200,33 @@ impl BlockState {
 
 impl SemanticContext for BlockState {
     fn expression_value(&mut self, expression: Value, register_number: u64) {
-        self.context.expression_value(expression, register_number);
+        self.context
+            .expression_value(expression.clone(), register_number);
+        if let Some(parent) = &self.parent {
+            parent
+                .borrow_mut()
+                .expression_value(expression, register_number);
+        }
     }
 
     fn expression_const(&mut self, expression: Constant, register_number: u64) {
-        self.context.expression_const(expression, register_number);
+        self.context
+            .expression_const(expression.clone(), register_number);
+        if let Some(parent) = &self.parent {
+            parent
+                .borrow_mut()
+                .expression_const(expression, register_number);
+        }
     }
 
     fn expression_struct_value(&mut self, expression: Value, index: u32, register_number: u64) {
         self.context
-            .expression_struct_value(expression, index, register_number)
+            .expression_struct_value(expression.clone(), index, register_number);
+        if let Some(parent) = &self.parent {
+            parent
+                .borrow_mut()
+                .expression_struct_value(expression, index, register_number)
+        }
     }
 
     fn expression_operation(
@@ -219,37 +236,74 @@ impl SemanticContext for BlockState {
         right_value: ExpressionResult,
         register_number: u64,
     ) {
-        self.context
-            .expression_operation(operation, left_value, right_value, register_number);
+        self.context.expression_operation(
+            operation.clone(),
+            left_value.clone(),
+            right_value.clone(),
+            register_number,
+        );
+        if let Some(parent) = &self.parent {
+            parent.borrow_mut().expression_operation(
+                operation,
+                left_value,
+                right_value,
+                register_number,
+            );
+        }
     }
 
     fn call(&mut self, call: Function, params: Vec<ExpressionResult>, register_number: u64) {
-        self.context.call(call, params, register_number);
+        self.context
+            .call(call.clone(), params.clone(), register_number);
+        if let Some(parent) = &self.parent {
+            parent.borrow_mut().call(call, params, register_number);
+        }
     }
 
     fn let_binding(&mut self, let_decl: Value, expr_result: ExpressionResult) {
-        self.context.let_binding(let_decl, expr_result);
+        self.context
+            .let_binding(let_decl.clone(), expr_result.clone());
+        if let Some(parent) = &self.parent {
+            parent.borrow_mut().let_binding(let_decl, expr_result);
+        }
     }
 
     fn binding(&mut self, val: Value, expr_result: ExpressionResult) {
-        self.context.binding(val, expr_result);
+        self.context.binding(val.clone(), expr_result.clone());
+        if let Some(parent) = &self.parent {
+            parent.borrow_mut().binding(val, expr_result);
+        }
     }
 
     fn expression_function_return(&mut self, expr_result: ExpressionResult) {
-        self.context.expression_function_return(expr_result);
+        self.context.expression_function_return(expr_result.clone());
+        if let Some(parent) = &self.parent {
+            parent.borrow_mut().expression_function_return(expr_result);
+        }
     }
 
     fn expression_function_return_with_label(&mut self, expr_result: ExpressionResult) {
         self.context
-            .expression_function_return_with_label(expr_result);
+            .expression_function_return_with_label(expr_result.clone());
+        if let Some(parent) = &self.parent {
+            parent
+                .borrow_mut()
+                .expression_function_return_with_label(expr_result);
+        }
     }
 
     fn set_label(&mut self, label: LabelName) {
-        self.context.set_label(label);
+        self.context.set_label(label.clone());
+        if let Some(parent) = &self.parent {
+            parent.borrow_mut().set_label(label);
+        }
     }
 
     fn jump_to(&mut self, label: LabelName) {
-        self.context.jump_to(label);
+        self.context.jump_to(label.clone());
+        if let Some(parent) = &self.parent {
+            parent.borrow_mut().jump_to(label);
+        }
     }
 
     fn if_condition_expression(
@@ -258,8 +312,16 @@ impl SemanticContext for BlockState {
         label_if_begin: LabelName,
         label_if_end: LabelName,
     ) {
-        self.context
-            .if_condition_expression(expr_result, label_if_begin, label_if_end);
+        self.context.if_condition_expression(
+            expr_result.clone(),
+            label_if_begin.clone(),
+            label_if_end.clone(),
+        );
+        if let Some(parent) = &self.parent {
+            parent
+                .borrow_mut()
+                .if_condition_expression(expr_result, label_if_begin, label_if_end);
+        }
     }
 
     fn condition_expression(
@@ -269,12 +331,27 @@ impl SemanticContext for BlockState {
         condition: Condition,
         register_number: u64,
     ) {
-        self.context
-            .condition_expression(left_result, right_result, condition, register_number);
+        self.context.condition_expression(
+            left_result.clone(),
+            right_result.clone(),
+            condition.clone(),
+            register_number,
+        );
+        if let Some(parent) = &self.parent {
+            parent.borrow_mut().condition_expression(
+                left_result,
+                right_result,
+                condition,
+                register_number,
+            );
+        }
     }
 
     fn jump_function_return(&mut self, expr_result: ExpressionResult) {
-        self.context.jump_function_return(expr_result);
+        self.context.jump_function_return(expr_result.clone());
+        if let Some(parent) = &self.parent {
+            parent.borrow_mut().jump_function_return(expr_result);
+        }
     }
 
     fn logic_condition(
@@ -285,11 +362,19 @@ impl SemanticContext for BlockState {
         register_number: u64,
     ) {
         self.context.logic_condition(
-            logic_condition,
+            logic_condition.clone(),
             left_register_result,
             right_register_result,
             register_number,
         );
+        if let Some(parent) = &self.parent {
+            parent.borrow_mut().logic_condition(
+                logic_condition,
+                left_register_result,
+                right_register_result,
+                register_number,
+            );
+        }
     }
 
     fn if_condition_logic(
@@ -298,7 +383,15 @@ impl SemanticContext for BlockState {
         label_if_end: LabelName,
         result_register: u64,
     ) {
-        self.context
-            .if_condition_logic(label_if_begin, label_if_end, result_register);
+        self.context.if_condition_logic(
+            label_if_begin.clone(),
+            label_if_end.clone(),
+            result_register,
+        );
+        if let Some(parent) = &self.parent {
+            parent
+                .borrow_mut()
+                .if_condition_logic(label_if_begin, label_if_end, result_register);
+        }
     }
 }

--- a/src/types/block_state.rs
+++ b/src/types/block_state.rs
@@ -2,7 +2,10 @@
 //! Block state Semantic types.
 
 use super::semantic::SemanticStack;
-use super::{InnerValueName, LabelName, Value, ValueName};
+use super::{Constant, Function, InnerValueName, LabelName, Value, ValueName};
+use crate::types::condition::{Condition, LogicCondition};
+use crate::types::expression::{ExpressionOperations, ExpressionResult};
+use crate::types::semantic::SemanticContext;
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
@@ -41,7 +44,7 @@ pub struct BlockState {
     /// children states
     pub children: Vec<Rc<RefCell<BlockState>>>,
     /// Semantic stack context for Block state
-    pub context: SemanticStack,
+    context: SemanticStack,
 }
 
 impl BlockState {
@@ -71,6 +74,10 @@ impl BlockState {
             parent,
             context: SemanticStack::new(),
         }
+    }
+
+    pub fn get_context(&self) -> SemanticStack {
+        self.context.clone()
     }
 
     /// Set `last_register_number` for current and parent states
@@ -188,5 +195,110 @@ impl BlockState {
         if let Some(parent) = &self.parent {
             parent.borrow_mut().set_return();
         }
+    }
+}
+
+impl SemanticContext for BlockState {
+    fn expression_value(&mut self, expression: Value, register_number: u64) {
+        self.context.expression_value(expression, register_number);
+    }
+
+    fn expression_const(&mut self, expression: Constant, register_number: u64) {
+        self.context.expression_const(expression, register_number);
+    }
+
+    fn expression_struct_value(&mut self, expression: Value, index: u32, register_number: u64) {
+        self.context
+            .expression_struct_value(expression, index, register_number)
+    }
+
+    fn expression_operation(
+        &mut self,
+        operation: ExpressionOperations,
+        left_value: ExpressionResult,
+        right_value: ExpressionResult,
+        register_number: u64,
+    ) {
+        self.context
+            .expression_operation(operation, left_value, right_value, register_number);
+    }
+
+    fn call(&mut self, call: Function, params: Vec<ExpressionResult>, register_number: u64) {
+        self.context.call(call, params, register_number);
+    }
+
+    fn let_binding(&mut self, let_decl: Value, expr_result: ExpressionResult) {
+        self.context.let_binding(let_decl, expr_result);
+    }
+
+    fn binding(&mut self, val: Value, expr_result: ExpressionResult) {
+        self.context.binding(val, expr_result);
+    }
+
+    fn expression_function_return(&mut self, expr_result: ExpressionResult) {
+        self.context.expression_function_return(expr_result);
+    }
+
+    fn expression_function_return_with_label(&mut self, expr_result: ExpressionResult) {
+        self.context
+            .expression_function_return_with_label(expr_result);
+    }
+
+    fn set_label(&mut self, label: LabelName) {
+        self.context.set_label(label);
+    }
+
+    fn jump_to(&mut self, label: LabelName) {
+        self.context.jump_to(label);
+    }
+
+    fn if_condition_expression(
+        &mut self,
+        expr_result: ExpressionResult,
+        label_if_begin: LabelName,
+        label_if_end: LabelName,
+    ) {
+        self.context
+            .if_condition_expression(expr_result, label_if_begin, label_if_end);
+    }
+
+    fn condition_expression(
+        &mut self,
+        left_result: ExpressionResult,
+        right_result: ExpressionResult,
+        condition: Condition,
+        register_number: u64,
+    ) {
+        self.context
+            .condition_expression(left_result, right_result, condition, register_number);
+    }
+
+    fn jump_function_return(&mut self, expr_result: ExpressionResult) {
+        self.context.jump_function_return(expr_result);
+    }
+
+    fn logic_condition(
+        &mut self,
+        logic_condition: LogicCondition,
+        left_register_result: u64,
+        right_register_result: u64,
+        register_number: u64,
+    ) {
+        self.context.logic_condition(
+            logic_condition,
+            left_register_result,
+            right_register_result,
+            register_number,
+        );
+    }
+
+    fn if_condition_logic(
+        &mut self,
+        label_if_begin: LabelName,
+        label_if_end: LabelName,
+        result_register: u64,
+    ) {
+        self.context
+            .if_condition_logic(label_if_begin, label_if_end, result_register);
     }
 }

--- a/src/types/semantic.rs
+++ b/src/types/semantic.rs
@@ -7,6 +7,12 @@ use super::expression::{ExpressionOperations, ExpressionResult};
 use super::types::StructTypes;
 use super::{Constant, Function, FunctionStatement, LabelName, Value};
 
+pub trait GlobalSemanticContext {
+    fn function_declaration(&mut self, fn_decl: FunctionStatement);
+    fn constant(&mut self, const_decl: Constant);
+    fn types(&mut self, type_decl: StructTypes);
+}
+
 /// Semantic Context trait contain instructions set functions
 /// for the Stack context.
 pub trait SemanticContext {
@@ -23,9 +29,6 @@ pub trait SemanticContext {
     fn call(&mut self, call: Function, params: Vec<ExpressionResult>, register_number: u64);
     fn let_binding(&mut self, let_decl: Value, expr_result: ExpressionResult);
     fn binding(&mut self, val: Value, expr_result: ExpressionResult);
-    fn function_declaration(&mut self, fn_decl: FunctionStatement);
-    fn constant(&mut self, const_decl: Constant);
-    fn types(&mut self, type_decl: StructTypes);
     fn expression_function_return(&mut self, expr_result: ExpressionResult);
     fn expression_function_return_with_label(&mut self, expr_result: ExpressionResult);
     fn set_label(&mut self, label: LabelName);
@@ -78,6 +81,35 @@ impl SemanticStack {
     /// Get all context stack data as array data
     pub fn get(self) -> Vec<SemanticStackContext> {
         self.0
+    }
+}
+
+impl GlobalSemanticContext for SemanticStack {
+    /// Push Context to the stack as function declaration data.
+    /// Function declaration instruction.
+    ///
+    /// ## Parameters
+    /// - `fn_decl` - function declaration parameters
+    fn function_declaration(&mut self, fn_decl: FunctionStatement) {
+        self.push(SemanticStackContext::FunctionDeclaration { fn_decl });
+    }
+
+    /// Push Context to the stack as constant data.
+    /// Constant declaration instruction.
+    ///
+    /// ## Parameters
+    /// - `const_decl` - constant declaration parameters
+    fn constant(&mut self, const_decl: Constant) {
+        self.push(SemanticStackContext::Constant { const_decl });
+    }
+
+    /// Push Context to the stack as types data.
+    /// Types declaration instruction.
+    ///
+    /// ## Parameters
+    /// - `type_decl` - type declaration parameters
+    fn types(&mut self, type_decl: StructTypes) {
+        self.push(SemanticStackContext::Types { type_decl });
     }
 }
 
@@ -182,33 +214,6 @@ impl SemanticContext for SemanticStack {
     /// -  `expr_result` - expression result that will be bind to the value
     fn binding(&mut self, val: Value, expr_result: ExpressionResult) {
         self.push(SemanticStackContext::Binding { val, expr_result });
-    }
-
-    /// Push Context to the stack as function declaration data.
-    /// Function declaration instruction.
-    ///
-    /// ## Parameters
-    /// - `fn_decl` - function declaration parameters
-    fn function_declaration(&mut self, fn_decl: FunctionStatement) {
-        self.push(SemanticStackContext::FunctionDeclaration { fn_decl });
-    }
-
-    /// Push Context to the stack as constant data.
-    /// Constant declaration instruction.
-    ///
-    /// ## Parameters
-    /// - `const_decl` - constant declaration parameters
-    fn constant(&mut self, const_decl: Constant) {
-        self.push(SemanticStackContext::Constant { const_decl });
-    }
-
-    /// Push Context to the stack as types data.
-    /// Types declaration instruction.
-    ///
-    /// ## Parameters
-    /// - `type_decl` - type declaration parameters
-    fn types(&mut self, type_decl: StructTypes) {
-        self.push(SemanticStackContext::Types { type_decl });
     }
 
     /// Push Context to the stack as expression function return data.

--- a/src/types/semantic.rs
+++ b/src/types/semantic.rs
@@ -7,6 +7,58 @@ use super::expression::{ExpressionOperations, ExpressionResult};
 use super::types::StructTypes;
 use super::{Constant, Function, FunctionStatement, LabelName, Value};
 
+/// Semantic Context trait contain instructions set functions
+/// for the Stack context.
+pub trait SemanticContext {
+    fn expression_value(&mut self, expression: Value, register_number: u64);
+    fn expression_const(&mut self, expression: Constant, register_number: u64);
+    fn expression_struct_value(&mut self, expression: Value, index: u32, register_number: u64);
+    fn expression_operation(
+        &mut self,
+        operation: ExpressionOperations,
+        left_value: ExpressionResult,
+        right_value: ExpressionResult,
+        register_number: u64,
+    );
+    fn call(&mut self, call: Function, params: Vec<ExpressionResult>, register_number: u64);
+    fn let_binding(&mut self, let_decl: Value, expr_result: ExpressionResult);
+    fn binding(&mut self, val: Value, expr_result: ExpressionResult);
+    fn function_declaration(&mut self, fn_decl: FunctionStatement);
+    fn constant(&mut self, const_decl: Constant);
+    fn types(&mut self, type_decl: StructTypes);
+    fn expression_function_return(&mut self, expr_result: ExpressionResult);
+    fn expression_function_return_with_label(&mut self, expr_result: ExpressionResult);
+    fn set_label(&mut self, label: LabelName);
+    fn jump_to(&mut self, label: LabelName);
+    fn if_condition_expression(
+        &mut self,
+        expr_result: ExpressionResult,
+        label_if_begin: LabelName,
+        label_if_end: LabelName,
+    );
+    fn condition_expression(
+        &mut self,
+        left_result: ExpressionResult,
+        right_result: ExpressionResult,
+        condition: Condition,
+        register_number: u64,
+    );
+    fn jump_function_return(&mut self, expr_result: ExpressionResult);
+    fn logic_condition(
+        &mut self,
+        logic_condition: LogicCondition,
+        left_register_result: u64,
+        right_register_result: u64,
+        register_number: u64,
+    );
+    fn if_condition_logic(
+        &mut self,
+        label_if_begin: LabelName,
+        label_if_end: LabelName,
+        result_register: u64,
+    );
+}
+
 /// # Semantic stack
 /// Semantic stack represent stack of Semantic Context results
 #[derive(Debug, Default, Clone, PartialEq)]
@@ -27,13 +79,15 @@ impl SemanticStack {
     pub fn get(self) -> Vec<SemanticStackContext> {
         self.0
     }
+}
 
+impl SemanticContext for SemanticStack {
     /// Push Context to the stack as expression value data.
     ///
     /// ## Parameters
     /// - `expression` - contains expression value
     /// - `register_number` - register to store result data
-    pub fn expression_value(&mut self, expression: Value, register_number: u64) {
+    fn expression_value(&mut self, expression: Value, register_number: u64) {
         self.push(SemanticStackContext::ExpressionValue {
             expression,
             register_number,
@@ -45,7 +99,7 @@ impl SemanticStack {
     /// ## Parameters
     /// - `expression` - contains expression constant
     /// - `register_number` - register to store result data
-    pub fn expression_const(&mut self, expression: Constant, register_number: u64) {
+    fn expression_const(&mut self, expression: Constant, register_number: u64) {
         self.push(SemanticStackContext::ExpressionConst {
             expression,
             register_number,
@@ -58,7 +112,7 @@ impl SemanticStack {
     /// - `expression` - contains expression value for specific `Structure` attribute
     /// - `index` - represent attribute index in the `Structure` type
     /// - `register_number` - register to store result data
-    pub fn expression_struct_value(&mut self, expression: Value, index: u32, register_number: u64) {
+    fn expression_struct_value(&mut self, expression: Value, index: u32, register_number: u64) {
         self.push(SemanticStackContext::ExpressionStructValue {
             expression,
             index,
@@ -75,7 +129,7 @@ impl SemanticStack {
     /// - `left_value` - left expression result
     /// - `right_value` - right expression result
     /// - `register_number` - register to store result of expression operation
-    pub fn expression_operation(
+    fn expression_operation(
         &mut self,
         operation: ExpressionOperations,
         left_value: ExpressionResult,
@@ -97,7 +151,7 @@ impl SemanticStack {
     /// - `call` - function declaration data
     /// - `params` - function parameters
     ///  - `register_number` - register to store result of function call
-    pub fn call(&mut self, call: Function, params: Vec<ExpressionResult>, register_number: u64) {
+    fn call(&mut self, call: Function, params: Vec<ExpressionResult>, register_number: u64) {
         self.push(SemanticStackContext::Call {
             call,
             params,
@@ -112,7 +166,7 @@ impl SemanticStack {
     /// ## Parameters
     /// - `let_decl` - value declaration
     /// -  `expr_result` - expression result that will be bind to the value
-    pub fn let_binding(&mut self, let_decl: Value, expr_result: ExpressionResult) {
+    fn let_binding(&mut self, let_decl: Value, expr_result: ExpressionResult) {
         self.push(SemanticStackContext::LetBinding {
             let_decl,
             expr_result,
@@ -126,7 +180,7 @@ impl SemanticStack {
     /// ## Parameters
     /// - `val` - value declaration
     /// -  `expr_result` - expression result that will be bind to the value
-    pub fn binding(&mut self, val: Value, expr_result: ExpressionResult) {
+    fn binding(&mut self, val: Value, expr_result: ExpressionResult) {
         self.push(SemanticStackContext::Binding { val, expr_result });
     }
 
@@ -135,7 +189,7 @@ impl SemanticStack {
     ///
     /// ## Parameters
     /// - `fn_decl` - function declaration parameters
-    pub fn function_declaration(&mut self, fn_decl: FunctionStatement) {
+    fn function_declaration(&mut self, fn_decl: FunctionStatement) {
         self.push(SemanticStackContext::FunctionDeclaration { fn_decl });
     }
 
@@ -144,7 +198,7 @@ impl SemanticStack {
     ///
     /// ## Parameters
     /// - `const_decl` - constant declaration parameters
-    pub fn constant(&mut self, const_decl: Constant) {
+    fn constant(&mut self, const_decl: Constant) {
         self.push(SemanticStackContext::Constant { const_decl });
     }
 
@@ -153,7 +207,7 @@ impl SemanticStack {
     ///
     /// ## Parameters
     /// - `type_decl` - type declaration parameters
-    pub fn types(&mut self, type_decl: StructTypes) {
+    fn types(&mut self, type_decl: StructTypes) {
         self.push(SemanticStackContext::Types { type_decl });
     }
 
@@ -163,7 +217,7 @@ impl SemanticStack {
     ///
     /// ## Parameters
     /// - `expr_result` - result data for the return
-    pub fn expression_function_return(&mut self, expr_result: ExpressionResult) {
+    fn expression_function_return(&mut self, expr_result: ExpressionResult) {
         self.push(SemanticStackContext::ExpressionFunctionReturn { expr_result });
     }
 
@@ -177,7 +231,7 @@ impl SemanticStack {
     ///
     /// ## Parameters
     /// - `expr_result` - result data for the return
-    pub fn expression_function_return_with_label(&mut self, expr_result: ExpressionResult) {
+    fn expression_function_return_with_label(&mut self, expr_result: ExpressionResult) {
         self.push(SemanticStackContext::ExpressionFunctionReturnWithLabel { expr_result });
     }
 
@@ -186,7 +240,7 @@ impl SemanticStack {
     ///
     /// ## Parameters
     /// - `label` - label name
-    pub fn set_label(&mut self, label: LabelName) {
+    fn set_label(&mut self, label: LabelName) {
         self.push(SemanticStackContext::SetLabel { label });
     }
 
@@ -195,7 +249,7 @@ impl SemanticStack {
     ///
     /// ## Parameters
     /// - `label` - label for the jump
-    pub fn jump_to(&mut self, label: LabelName) {
+    fn jump_to(&mut self, label: LabelName) {
         self.push(SemanticStackContext::JumpTo { label });
     }
 
@@ -208,7 +262,7 @@ impl SemanticStack {
     /// conditional instruction
     /// - `label_if_begin` - label for jump if expression is "true"
     /// - `label_if_end` - label for jump if expression is "false"
-    pub fn if_condition_expression(
+    fn if_condition_expression(
         &mut self,
         expr_result: ExpressionResult,
         label_if_begin: LabelName,
@@ -229,7 +283,7 @@ impl SemanticStack {
     /// - `right_result` - right expression result
     /// - `condition` - condition operation
     /// - `register_number` - register to store result of expression operation
-    pub fn condition_expression(
+    fn condition_expression(
         &mut self,
         left_result: ExpressionResult,
         right_result: ExpressionResult,
@@ -251,7 +305,7 @@ impl SemanticStack {
     ///
     /// ## Parameters
     /// - `expr_result` - expression result for return condition
-    pub fn jump_function_return(&mut self, expr_result: ExpressionResult) {
+    fn jump_function_return(&mut self, expr_result: ExpressionResult) {
         self.push(SemanticStackContext::JumpFunctionReturn { expr_result });
     }
 
@@ -263,7 +317,7 @@ impl SemanticStack {
     /// - left_register_result - result of left condition
     /// - right_register_result - result of right condition
     /// - register_number - register to store instruction result
-    pub fn logic_condition(
+    fn logic_condition(
         &mut self,
         logic_condition: LogicCondition,
         left_register_result: u64,
@@ -292,7 +346,7 @@ impl SemanticStack {
     /// example `if_else`)
     /// - `result_register` - contains register of previous condition logic
     /// calculations.
-    pub fn if_condition_logic(
+    fn if_condition_logic(
         &mut self,
         label_if_begin: LabelName,
         label_if_end: LabelName,

--- a/tests/binding_tests.rs
+++ b/tests/binding_tests.rs
@@ -99,7 +99,7 @@ fn binding_value_not_mutable() {
         malloc: false,
     };
 
-    let state = block_state.borrow().context.clone().get();
+    let state = block_state.borrow().get_context().get();
     assert_eq!(state.len(), 1);
     assert_eq!(
         state[0],
@@ -154,7 +154,7 @@ fn binding_value_found() {
         malloc: false,
     };
 
-    let state = block_state.borrow().context.clone().get();
+    let state = block_state.borrow().get_context().clone().get();
     assert_eq!(state.len(), 1);
     assert_eq!(
         state[0],
@@ -181,7 +181,7 @@ fn binding_value_found() {
     };
     t.state.binding(&binding, &block_state);
     assert!(t.is_empty_error());
-    let state = block_state.borrow().context.clone().get();
+    let state = block_state.borrow().get_context().clone().get();
     assert_eq!(state.len(), 2);
     assert_eq!(
         state[0],

--- a/tests/expressions_tests.rs
+++ b/tests/expressions_tests.rs
@@ -389,7 +389,7 @@ fn expression_value_name_not_found() {
         "Errors: {:?}",
         t.state.errors[0]
     );
-    let state = block_state.borrow().context.clone().get();
+    let state = block_state.borrow().get_context().clone().get();
     assert!(state.is_empty());
     assert!(t.check_errors_len(1), "Errors: {:?}", t.state.errors.len());
 }
@@ -418,7 +418,7 @@ fn expression_value_name_exists() {
     let res = t.state.expression(&expr, &block_state).unwrap();
     assert_eq!(res.expr_value, ExpressionResultValue::Register(1));
     assert_eq!(res.expr_type, ty);
-    let state = block_state.borrow().context.clone().get();
+    let state = block_state.borrow().get_context().clone().get();
     assert_eq!(state.len(), 1);
     assert_eq!(
         state[0],
@@ -454,7 +454,7 @@ fn expression_const_exists() {
     let res = t.state.expression(&expr, &block_state).unwrap();
     assert_eq!(res.expr_value, ExpressionResultValue::Register(1));
     assert_eq!(res.expr_type, ty);
-    let state = block_state.borrow().context.clone().get();
+    let state = block_state.borrow().get_context().clone().get();
     assert_eq!(state.len(), 1);
     assert_eq!(
         state[0],
@@ -480,7 +480,7 @@ fn expression_primitive_value() {
         ExpressionResultValue::PrimitiveValue(PrimitiveValue::I32(10))
     );
     assert_eq!(res.expr_type, Type::Primitive(PrimitiveTypes::I32));
-    let state = block_state.borrow().context.clone().get();
+    let state = block_state.borrow().get_context().clone().get();
     assert!(state.is_empty());
     assert!(t.is_empty_error());
 }
@@ -794,7 +794,7 @@ fn expression_struct_value() {
     assert!(t.is_empty_error());
     assert_eq!(res.expr_value, ExpressionResultValue::Register(2));
     assert_eq!(res.expr_type, Type::Primitive(PrimitiveTypes::Bool));
-    let state = block_state.borrow().context.clone().get();
+    let state = block_state.borrow().get_context().clone().get();
     assert_eq!(state.len(), 1);
     assert_eq!(
         state[0],
@@ -853,7 +853,7 @@ fn expression_func_call() {
             expr_type: Type::Primitive(PrimitiveTypes::Ptr)
         }
     );
-    let state = block_state.borrow().context.clone().get();
+    let state = block_state.borrow().get_context().clone().get();
     assert_eq!(state.len(), 1);
     assert_eq!(
         state[0],
@@ -890,7 +890,7 @@ fn expression_sub_expression() {
             expr_type: Type::Primitive(PrimitiveTypes::U32)
         }
     );
-    let state = block_state.borrow().context.clone().get();
+    let state = block_state.borrow().get_context().clone().get();
     assert!(state.is_empty());
 }
 
@@ -915,7 +915,7 @@ fn expression_operation() {
             expr_value: ExpressionResultValue::Register(1)
         }
     );
-    let state = block_state.borrow().context.clone().get();
+    let state = block_state.borrow().get_context().clone().get();
     assert_eq!(state.len(), 1);
     assert_eq!(
         state[0],
@@ -954,7 +954,7 @@ fn expression_operation_wrong_type() {
         t.state.errors[0]
     );
     assert!(res.is_none());
-    let state = block_state.borrow().context.clone().get();
+    let state = block_state.borrow().get_context().clone().get();
     assert!(state.is_empty());
 }
 
@@ -999,7 +999,7 @@ fn expression_multiple_operation1() {
     let res = t.state.expression(&expr, &block_state).unwrap();
     assert_eq!(res.expr_type, Type::Primitive(PrimitiveTypes::U16));
     assert_eq!(res.expr_value, ExpressionResultValue::Register(5));
-    let state = block_state.borrow().context.clone().get();
+    let state = block_state.borrow().get_context().clone().get();
     assert_eq!(state.len(), 5);
     assert_eq!(state[0], set_result_type(Plus, false, 1, false, 2, 1));
     assert_eq!(state[1], set_result_type(Multiply, true, 1, false, 3, 2));
@@ -1059,7 +1059,7 @@ fn expression_multiple_operation2() {
     let res = t.state.expression(&expr, &block_state).unwrap();
     assert_eq!(res.expr_type, Type::Primitive(PrimitiveTypes::U16));
     assert_eq!(res.expr_value, ExpressionResultValue::Register(5));
-    let state = block_state.borrow().context.clone().get();
+    let state = block_state.borrow().get_context().clone().get();
     assert_eq!(state.len(), 5);
     assert_eq!(state[0], set_result_type(Plus, false, 100, false, 2, 1));
     assert_eq!(state[1], set_result_type(Minus, false, 3, false, 4, 2));
@@ -1092,7 +1092,7 @@ fn expression_multiple_operation_simple1() {
     let res = t.state.expression(&expr, &block_state).unwrap();
     assert_eq!(res.expr_type, Type::Primitive(PrimitiveTypes::U16));
     assert_eq!(res.expr_value, ExpressionResultValue::Register(2));
-    let state = block_state.borrow().context.clone().get();
+    let state = block_state.borrow().get_context().clone().get();
     assert_eq!(state.len(), 2);
     assert_eq!(state[0], set_result_type(Multiply, false, 5, false, 6, 1));
     assert_eq!(state[1], set_result_type(Minus, false, 100, true, 1, 2));
@@ -1119,7 +1119,7 @@ fn expression_multiple_operation_simple2() {
     let res = t.state.expression(&expr, &block_state).unwrap();
     assert_eq!(res.expr_type, Type::Primitive(PrimitiveTypes::U16));
     assert_eq!(res.expr_value, ExpressionResultValue::Register(2));
-    let state = block_state.borrow().context.clone().get();
+    let state = block_state.borrow().get_context().clone().get();
     assert_eq!(state.len(), 2);
     assert_eq!(state[0], set_result_type(Multiply, false, 20, false, 5, 1));
     assert_eq!(state[1], set_result_type(Minus, true, 1, false, 40, 2));
@@ -1150,7 +1150,7 @@ fn expression_multiple_operation_simple3() {
     let res = t.state.expression(&expr, &block_state).unwrap();
     assert_eq!(res.expr_type, Type::Primitive(PrimitiveTypes::U16));
     assert_eq!(res.expr_value, ExpressionResultValue::Register(3));
-    let state = block_state.borrow().context.clone().get();
+    let state = block_state.borrow().get_context().clone().get();
     assert_eq!(state.len(), 3);
     assert_eq!(state[0], set_result_type(Multiply, false, 20, false, 4, 1));
     assert_eq!(state[1], set_result_type(Minus, true, 1, false, 40, 2));
@@ -1186,7 +1186,7 @@ fn expression_multiple_operation_simple4() {
     let res = t.state.expression(&expr, &block_state).unwrap();
     assert_eq!(res.expr_type, Type::Primitive(PrimitiveTypes::U16));
     assert_eq!(res.expr_value, ExpressionResultValue::Register(3));
-    let state = block_state.borrow().context.clone().get();
+    let state = block_state.borrow().get_context().clone().get();
     assert_eq!(state.len(), 3);
     assert_eq!(state[0], set_result_type(Multiply, false, 5, false, 6, 1));
     assert_eq!(state[1], set_result_type(Minus, false, 100, true, 1, 2));

--- a/tests/if_tests.rs
+++ b/tests/if_tests.rs
@@ -778,7 +778,8 @@ fn else_if_statement() {
     );
     assert!(t.is_empty_error());
 
-    assert!(block_state.borrow().get_context().clone().get().is_empty());
+    let main_ctx = block_state.borrow().get_context().clone().get();
+    assert_eq!(main_ctx.len(), 10);
     assert!(block_state.borrow().parent.is_none());
     assert_eq!(block_state.borrow().children.len(), 3);
 
@@ -807,12 +808,14 @@ fn else_if_statement() {
             label_if_end: String::from("if_else").into()
         }
     );
+    assert_eq!(ctx1[0], main_ctx[0]);
     assert_eq!(
         ctx1[1],
         SemanticStackContext::SetLabel {
             label: String::from("if_begin").into()
         }
     );
+    assert_eq!(ctx1[1], main_ctx[1]);
     assert_eq!(
         ctx1[2],
         SemanticStackContext::JumpFunctionReturn {
@@ -822,18 +825,21 @@ fn else_if_statement() {
             }
         }
     );
+    assert_eq!(ctx1[2], main_ctx[2]);
     assert_eq!(
         ctx1[3],
         SemanticStackContext::SetLabel {
             label: String::from("if_else").into()
         }
     );
+    assert_eq!(ctx1[3], main_ctx[3]);
     assert_eq!(
         ctx1[4],
         SemanticStackContext::SetLabel {
             label: String::from("if_end").into()
         }
     );
+    assert_eq!(ctx1[4], main_ctx[9]);
 
     let ctx2 = ch_ctx2.borrow().get_context().clone().get();
     assert_eq!(ctx2.len(), 4);
@@ -848,12 +854,14 @@ fn else_if_statement() {
             label_if_end: String::from("if_else.0").into()
         }
     );
+    assert_eq!(ctx2[0], main_ctx[4]);
     assert_eq!(
         ctx2[1],
         SemanticStackContext::SetLabel {
             label: String::from("if_begin.0").into()
         }
     );
+    assert_eq!(ctx2[1], main_ctx[5]);
     assert_eq!(
         ctx2[2],
         SemanticStackContext::JumpFunctionReturn {
@@ -863,12 +871,14 @@ fn else_if_statement() {
             }
         }
     );
+    assert_eq!(ctx2[2], main_ctx[6]);
     assert_eq!(
         ctx2[3],
         SemanticStackContext::SetLabel {
             label: String::from("if_else.0").into()
         }
     );
+    assert_eq!(ctx2[3], main_ctx[7]);
 
     let ctx3 = ch_ctx3.borrow().get_context().clone().get();
     assert_eq!(ctx3.len(), 1);
@@ -881,6 +891,7 @@ fn else_if_statement() {
             }
         }
     );
+    assert_eq!(ctx3[0], main_ctx[8]);
 }
 
 #[test]
@@ -975,92 +986,14 @@ fn if_body_statements() {
     );
     assert!(t.is_empty_error());
 
-    assert!(block_state.borrow().get_context().clone().get().is_empty());
+    let main_ctx = block_state.borrow().get_context().get();
+    assert_eq!(main_ctx.len(), 16);
     assert!(block_state.borrow().parent.is_none());
     assert_eq!(block_state.borrow().children.len(), 1);
 
     let ctx = block_state.borrow().children[0].clone();
     assert!(ctx.borrow().parent.is_some());
     assert_eq!(ctx.borrow().children.len(), 2);
-
-    let stm_ctx = ctx.borrow().get_context().clone().get();
-    assert_eq!(stm_ctx.len(), 7);
-    assert_eq!(
-        stm_ctx[0],
-        SemanticStackContext::IfConditionExpression {
-            expr_result: ExpressionResult {
-                expr_type: Type::Primitive(PrimitiveTypes::U64),
-                expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::U64(1)),
-            },
-            label_if_begin: String::from("if_begin").into(),
-            label_if_end: String::from("if_end").into()
-        }
-    );
-    assert_eq!(
-        stm_ctx[1],
-        SemanticStackContext::SetLabel {
-            label: String::from("if_begin").into()
-        }
-    );
-    assert_eq!(
-        stm_ctx[2],
-        SemanticStackContext::LetBinding {
-            let_decl: Value {
-                inner_name: "x.0".into(),
-                inner_type: Type::Primitive(PrimitiveTypes::Bool),
-                mutable: true,
-                alloca: false,
-                malloc: false
-            },
-            expr_result: ExpressionResult {
-                expr_type: Type::Primitive(PrimitiveTypes::Bool),
-                expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::Bool(false)),
-            },
-        }
-    );
-    assert_eq!(
-        stm_ctx[3],
-        SemanticStackContext::Binding {
-            val: Value {
-                inner_name: "x.0".into(),
-                inner_type: Type::Primitive(PrimitiveTypes::Bool),
-                mutable: true,
-                alloca: false,
-                malloc: false
-            },
-            expr_result: ExpressionResult {
-                expr_type: Type::Primitive(PrimitiveTypes::Bool),
-                expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::Bool(true)),
-            },
-        }
-    );
-    assert_eq!(
-        stm_ctx[4],
-        SemanticStackContext::Call {
-            call: Function {
-                inner_name: String::from("fn2").into(),
-                inner_type: Type::Primitive(PrimitiveTypes::U16),
-                parameters: vec![],
-            },
-            params: vec![],
-            register_number: 1
-        }
-    );
-    assert_eq!(
-        stm_ctx[5],
-        SemanticStackContext::JumpFunctionReturn {
-            expr_result: ExpressionResult {
-                expr_type: Type::Primitive(PrimitiveTypes::Bool),
-                expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::Bool(true)),
-            }
-        }
-    );
-    assert_eq!(
-        stm_ctx[6],
-        SemanticStackContext::SetLabel {
-            label: String::from("if_end").into()
-        }
-    );
 
     let ch_ctx1 = ctx.borrow().children[0].clone();
     assert!(ch_ctx1.borrow().parent.is_some());
@@ -1145,6 +1078,95 @@ fn if_body_statements() {
         ctx2[4],
         SemanticStackContext::SetLabel {
             label: String::from("loop_end").into()
+        }
+    );
+
+    let stm_ctx = ctx.borrow().get_context().clone().get();
+    assert_eq!(stm_ctx.len(), 16);
+    assert_eq!(stm_ctx, main_ctx);
+    assert_eq!(
+        stm_ctx[0],
+        SemanticStackContext::IfConditionExpression {
+            expr_result: ExpressionResult {
+                expr_type: Type::Primitive(PrimitiveTypes::U64),
+                expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::U64(1)),
+            },
+            label_if_begin: String::from("if_begin").into(),
+            label_if_end: String::from("if_end").into()
+        }
+    );
+    assert_eq!(
+        stm_ctx[1],
+        SemanticStackContext::SetLabel {
+            label: String::from("if_begin").into()
+        }
+    );
+    assert_eq!(
+        stm_ctx[2],
+        SemanticStackContext::LetBinding {
+            let_decl: Value {
+                inner_name: "x.0".into(),
+                inner_type: Type::Primitive(PrimitiveTypes::Bool),
+                mutable: true,
+                alloca: false,
+                malloc: false
+            },
+            expr_result: ExpressionResult {
+                expr_type: Type::Primitive(PrimitiveTypes::Bool),
+                expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::Bool(false)),
+            },
+        }
+    );
+    assert_eq!(
+        stm_ctx[3],
+        SemanticStackContext::Binding {
+            val: Value {
+                inner_name: "x.0".into(),
+                inner_type: Type::Primitive(PrimitiveTypes::Bool),
+                mutable: true,
+                alloca: false,
+                malloc: false
+            },
+            expr_result: ExpressionResult {
+                expr_type: Type::Primitive(PrimitiveTypes::Bool),
+                expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::Bool(true)),
+            },
+        }
+    );
+    assert_eq!(
+        stm_ctx[4],
+        SemanticStackContext::Call {
+            call: Function {
+                inner_name: String::from("fn2").into(),
+                inner_type: Type::Primitive(PrimitiveTypes::U16),
+                parameters: vec![],
+            },
+            params: vec![],
+            register_number: 1
+        }
+    );
+    assert_eq!(stm_ctx[5], ctx1[0]);
+    assert_eq!(stm_ctx[6], ctx1[1]);
+    assert_eq!(stm_ctx[7], ctx1[2]);
+    assert_eq!(stm_ctx[8], ctx1[3]);
+    assert_eq!(stm_ctx[9], ctx2[0]);
+    assert_eq!(stm_ctx[10], ctx2[1]);
+    assert_eq!(stm_ctx[11], ctx2[2]);
+    assert_eq!(stm_ctx[12], ctx2[3]);
+    assert_eq!(stm_ctx[13], ctx2[4]);
+    assert_eq!(
+        stm_ctx[14],
+        SemanticStackContext::JumpFunctionReturn {
+            expr_result: ExpressionResult {
+                expr_type: Type::Primitive(PrimitiveTypes::Bool),
+                expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::Bool(true)),
+            }
+        }
+    );
+    assert_eq!(
+        stm_ctx[15],
+        SemanticStackContext::SetLabel {
+            label: String::from("if_end").into()
         }
     );
 }
@@ -1251,93 +1273,15 @@ fn if_loop_body_statements() {
     );
     assert!(t.is_empty_error());
 
+    let main_ctx = block_state.borrow().get_context().clone().get();
+    assert_eq!(main_ctx.len(), 16);
     assert!(block_state.borrow().parent.is_none());
-    assert_eq!(block_state.borrow().get_context().clone().get().len(), 0);
     assert!(block_state.borrow().parent.is_none());
     assert_eq!(block_state.borrow().children.len(), 1);
 
     let ctx = block_state.borrow().children[0].clone();
     assert!(ctx.borrow().parent.is_some());
     assert_eq!(ctx.borrow().children.len(), 2);
-
-    let stm_ctx = ctx.borrow().get_context().clone().get();
-    assert_eq!(stm_ctx.len(), 7);
-    assert_eq!(
-        stm_ctx[0],
-        SemanticStackContext::IfConditionExpression {
-            expr_result: ExpressionResult {
-                expr_type: Type::Primitive(PrimitiveTypes::U64),
-                expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::U64(1)),
-            },
-            label_if_begin: String::from("if_begin").into(),
-            label_if_end: String::from("if_end").into()
-        }
-    );
-    assert_eq!(
-        stm_ctx[1],
-        SemanticStackContext::SetLabel {
-            label: String::from("if_begin").into()
-        }
-    );
-    assert_eq!(
-        stm_ctx[2],
-        SemanticStackContext::LetBinding {
-            let_decl: Value {
-                inner_name: "x.0".into(),
-                inner_type: Type::Primitive(PrimitiveTypes::Bool),
-                mutable: true,
-                alloca: false,
-                malloc: false
-            },
-            expr_result: ExpressionResult {
-                expr_type: Type::Primitive(PrimitiveTypes::Bool),
-                expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::Bool(false)),
-            },
-        }
-    );
-    assert_eq!(
-        stm_ctx[3],
-        SemanticStackContext::Binding {
-            val: Value {
-                inner_name: "x.0".into(),
-                inner_type: Type::Primitive(PrimitiveTypes::Bool),
-                mutable: true,
-                alloca: false,
-                malloc: false
-            },
-            expr_result: ExpressionResult {
-                expr_type: Type::Primitive(PrimitiveTypes::Bool),
-                expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::Bool(true)),
-            },
-        }
-    );
-    assert_eq!(
-        stm_ctx[4],
-        SemanticStackContext::Call {
-            call: Function {
-                inner_name: String::from("fn2").into(),
-                inner_type: Type::Primitive(PrimitiveTypes::U16),
-                parameters: vec![],
-            },
-            params: vec![],
-            register_number: 1
-        }
-    );
-    assert_eq!(
-        stm_ctx[5],
-        SemanticStackContext::JumpFunctionReturn {
-            expr_result: ExpressionResult {
-                expr_type: Type::Primitive(PrimitiveTypes::Bool),
-                expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::Bool(true)),
-            }
-        }
-    );
-    assert_eq!(
-        stm_ctx[6],
-        SemanticStackContext::SetLabel {
-            label: String::from("if_end").into()
-        }
-    );
 
     let ch_ctx1 = ctx.borrow().children[0].clone();
     assert!(ch_ctx1.borrow().parent.is_some());
@@ -1421,6 +1365,95 @@ fn if_loop_body_statements() {
         ctx2[4],
         SemanticStackContext::SetLabel {
             label: String::from("loop_end").into()
+        }
+    );
+
+    let stm_ctx = ctx.borrow().get_context().clone().get();
+    assert_eq!(stm_ctx.len(), 16);
+    assert_eq!(stm_ctx, main_ctx);
+    assert_eq!(
+        stm_ctx[0],
+        SemanticStackContext::IfConditionExpression {
+            expr_result: ExpressionResult {
+                expr_type: Type::Primitive(PrimitiveTypes::U64),
+                expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::U64(1)),
+            },
+            label_if_begin: String::from("if_begin").into(),
+            label_if_end: String::from("if_end").into()
+        }
+    );
+    assert_eq!(
+        stm_ctx[1],
+        SemanticStackContext::SetLabel {
+            label: String::from("if_begin").into()
+        }
+    );
+    assert_eq!(
+        stm_ctx[2],
+        SemanticStackContext::LetBinding {
+            let_decl: Value {
+                inner_name: "x.0".into(),
+                inner_type: Type::Primitive(PrimitiveTypes::Bool),
+                mutable: true,
+                alloca: false,
+                malloc: false
+            },
+            expr_result: ExpressionResult {
+                expr_type: Type::Primitive(PrimitiveTypes::Bool),
+                expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::Bool(false)),
+            },
+        }
+    );
+    assert_eq!(
+        stm_ctx[3],
+        SemanticStackContext::Binding {
+            val: Value {
+                inner_name: "x.0".into(),
+                inner_type: Type::Primitive(PrimitiveTypes::Bool),
+                mutable: true,
+                alloca: false,
+                malloc: false
+            },
+            expr_result: ExpressionResult {
+                expr_type: Type::Primitive(PrimitiveTypes::Bool),
+                expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::Bool(true)),
+            },
+        }
+    );
+    assert_eq!(
+        stm_ctx[4],
+        SemanticStackContext::Call {
+            call: Function {
+                inner_name: String::from("fn2").into(),
+                inner_type: Type::Primitive(PrimitiveTypes::U16),
+                parameters: vec![],
+            },
+            params: vec![],
+            register_number: 1
+        }
+    );
+    assert_eq!(stm_ctx[5], ctx1[0]);
+    assert_eq!(stm_ctx[6], ctx1[1]);
+    assert_eq!(stm_ctx[7], ctx1[2]);
+    assert_eq!(stm_ctx[8], ctx1[3]);
+    assert_eq!(stm_ctx[9], ctx2[0]);
+    assert_eq!(stm_ctx[10], ctx2[1]);
+    assert_eq!(stm_ctx[11], ctx2[2]);
+    assert_eq!(stm_ctx[12], ctx2[3]);
+    assert_eq!(stm_ctx[13], ctx2[4]);
+    assert_eq!(
+        stm_ctx[14],
+        SemanticStackContext::JumpFunctionReturn {
+            expr_result: ExpressionResult {
+                expr_type: Type::Primitive(PrimitiveTypes::Bool),
+                expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::Bool(true)),
+            }
+        }
+    );
+    assert_eq!(
+        stm_ctx[15],
+        SemanticStackContext::SetLabel {
+            label: String::from("if_end").into()
         }
     );
 }

--- a/tests/if_tests.rs
+++ b/tests/if_tests.rs
@@ -364,7 +364,7 @@ fn if_condition_calculation_simple() {
         true,
     );
 
-    let ctx = block_state.borrow().context.clone().get();
+    let ctx = block_state.borrow().get_context().clone().get();
     assert_eq!(ctx.len(), 2);
     assert_eq!(
         ctx[0],
@@ -477,7 +477,7 @@ fn if_condition_calculation_logic() {
         false,
     );
 
-    let ctx = block_state.borrow().context.clone().get();
+    let ctx = block_state.borrow().get_context().clone().get();
     assert_eq!(
         ctx[0],
         SemanticStackContext::ConditionExpression {
@@ -778,7 +778,7 @@ fn else_if_statement() {
     );
     assert!(t.is_empty_error());
 
-    assert!(block_state.borrow().context.clone().get().is_empty());
+    assert!(block_state.borrow().get_context().clone().get().is_empty());
     assert!(block_state.borrow().parent.is_none());
     assert_eq!(block_state.borrow().children.len(), 3);
 
@@ -794,7 +794,7 @@ fn else_if_statement() {
     assert!(ch_ctx3.borrow().parent.is_some());
     assert!(ch_ctx3.borrow().children.is_empty());
 
-    let ctx1 = ch_ctx1.borrow().context.clone().get();
+    let ctx1 = ch_ctx1.borrow().get_context().clone().get();
     assert_eq!(ctx1.len(), 5);
     assert_eq!(
         ctx1[0],
@@ -835,7 +835,7 @@ fn else_if_statement() {
         }
     );
 
-    let ctx2 = ch_ctx2.borrow().context.clone().get();
+    let ctx2 = ch_ctx2.borrow().get_context().clone().get();
     assert_eq!(ctx2.len(), 4);
     assert_eq!(
         ctx2[0],
@@ -870,7 +870,7 @@ fn else_if_statement() {
         }
     );
 
-    let ctx3 = ch_ctx3.borrow().context.clone().get();
+    let ctx3 = ch_ctx3.borrow().get_context().clone().get();
     assert_eq!(ctx3.len(), 1);
     assert_eq!(
         ctx3[0],
@@ -975,7 +975,7 @@ fn if_body_statements() {
     );
     assert!(t.is_empty_error());
 
-    assert!(block_state.borrow().context.clone().get().is_empty());
+    assert!(block_state.borrow().get_context().clone().get().is_empty());
     assert!(block_state.borrow().parent.is_none());
     assert_eq!(block_state.borrow().children.len(), 1);
 
@@ -983,7 +983,7 @@ fn if_body_statements() {
     assert!(ctx.borrow().parent.is_some());
     assert_eq!(ctx.borrow().children.len(), 2);
 
-    let stm_ctx = ctx.borrow().context.clone().get();
+    let stm_ctx = ctx.borrow().get_context().clone().get();
     assert_eq!(stm_ctx.len(), 7);
     assert_eq!(
         stm_ctx[0],
@@ -1066,7 +1066,7 @@ fn if_body_statements() {
     assert!(ch_ctx1.borrow().parent.is_some());
     assert!(ch_ctx1.borrow().children.is_empty());
 
-    let ctx1 = ch_ctx1.borrow().context.clone().get();
+    let ctx1 = ch_ctx1.borrow().get_context().clone().get();
     assert_eq!(ctx1.len(), 4);
     assert_eq!(
         ctx1[0],
@@ -1108,7 +1108,7 @@ fn if_body_statements() {
     assert!(ch_ctx2.borrow().parent.is_some());
     assert!(ch_ctx2.borrow().children.is_empty());
 
-    let ctx2 = ch_ctx2.borrow().context.clone().get();
+    let ctx2 = ch_ctx2.borrow().get_context().clone().get();
     assert_eq!(ctx2.len(), 5);
     assert_eq!(
         ctx2[0],
@@ -1252,7 +1252,7 @@ fn if_loop_body_statements() {
     assert!(t.is_empty_error());
 
     assert!(block_state.borrow().parent.is_none());
-    assert_eq!(block_state.borrow().context.clone().get().len(), 0);
+    assert_eq!(block_state.borrow().get_context().clone().get().len(), 0);
     assert!(block_state.borrow().parent.is_none());
     assert_eq!(block_state.borrow().children.len(), 1);
 
@@ -1260,7 +1260,7 @@ fn if_loop_body_statements() {
     assert!(ctx.borrow().parent.is_some());
     assert_eq!(ctx.borrow().children.len(), 2);
 
-    let stm_ctx = ctx.borrow().context.clone().get();
+    let stm_ctx = ctx.borrow().get_context().clone().get();
     assert_eq!(stm_ctx.len(), 7);
     assert_eq!(
         stm_ctx[0],
@@ -1343,7 +1343,7 @@ fn if_loop_body_statements() {
     assert!(ch_ctx1.borrow().parent.is_some());
     assert!(ch_ctx1.borrow().children.is_empty());
 
-    let ctx1 = ch_ctx1.borrow().context.clone().get();
+    let ctx1 = ch_ctx1.borrow().get_context().clone().get();
     assert_eq!(ctx1.len(), 4);
     assert_eq!(
         ctx1[0],
@@ -1385,7 +1385,7 @@ fn if_loop_body_statements() {
     assert!(ch_ctx2.borrow().parent.is_some());
     assert!(ch_ctx2.borrow().children.is_empty());
 
-    let ctx2 = ch_ctx2.borrow().context.clone().get();
+    let ctx2 = ch_ctx2.borrow().get_context().clone().get();
     assert_eq!(ctx2.len(), 5);
     assert_eq!(
         ctx2[0],

--- a/tests/let_binding_tests.rs
+++ b/tests/let_binding_tests.rs
@@ -101,7 +101,7 @@ fn let_binding_value_not_found() {
     };
     t.state.let_binding(&let_binding, &block_state);
     assert!(t.is_empty_error());
-    let state = block_state.borrow().context.clone().get();
+    let state = block_state.borrow().get_context().clone().get();
     assert_eq!(state.len(), 1);
     let inner_name: InnerValueName = "x.0".into();
     let val = Value {
@@ -156,7 +156,7 @@ fn let_binding_value_found() {
     };
     t.state.let_binding(&let_binding, &block_state);
     assert!(t.is_empty_error());
-    let state = block_state.borrow().context.clone().get();
+    let state = block_state.borrow().get_context().clone().get();
     assert_eq!(state.len(), 1);
 
     let val2 = Value {

--- a/tests/loop_tests.rs
+++ b/tests/loop_tests.rs
@@ -153,7 +153,7 @@ fn loop_statements() {
     t.state.loop_statement(&loop_stmt, &block_state);
 
     assert!(block_state.borrow().parent.is_none());
-    assert_eq!(block_state.borrow().context.clone().get().len(), 0);
+    assert_eq!(block_state.borrow().get_context().clone().get().len(), 0);
     assert!(block_state.borrow().parent.is_none());
     assert_eq!(block_state.borrow().children.len(), 1);
 
@@ -161,7 +161,7 @@ fn loop_statements() {
     assert!(ctx.borrow().parent.is_some());
     assert_eq!(ctx.borrow().children.len(), 2);
 
-    let stm_ctx = ctx.borrow().context.clone().get();
+    let stm_ctx = ctx.borrow().get_context().clone().get();
     assert_eq!(stm_ctx.len(), 7);
     assert_eq!(
         stm_ctx[0],
@@ -236,7 +236,7 @@ fn loop_statements() {
     assert!(ch_ctx1.borrow().parent.is_some());
     assert!(ch_ctx1.borrow().children.is_empty());
 
-    let ctx1 = ch_ctx1.borrow().context.clone().get();
+    let ctx1 = ch_ctx1.borrow().get_context().clone().get();
     assert_eq!(ctx1.len(), 5);
     assert_eq!(
         ctx1[0],
@@ -284,7 +284,7 @@ fn loop_statements() {
     assert!(ch_ctx2.borrow().parent.is_some());
     assert!(ch_ctx2.borrow().children.is_empty());
 
-    let ctx2 = ch_ctx2.borrow().context.clone().get();
+    let ctx2 = ch_ctx2.borrow().get_context().clone().get();
     assert_eq!(ctx2.len(), 5);
     assert_eq!(
         ctx2[0],
@@ -438,7 +438,7 @@ fn loop_statements_with_return_invocation() {
     t.state.loop_statement(&loop_stmt, &block_state);
 
     assert!(block_state.borrow().parent.is_none());
-    assert_eq!(block_state.borrow().context.clone().get().len(), 0);
+    assert_eq!(block_state.borrow().get_context().clone().get().len(), 0);
     assert!(block_state.borrow().parent.is_none());
     assert_eq!(block_state.borrow().children.len(), 1);
 
@@ -446,7 +446,7 @@ fn loop_statements_with_return_invocation() {
     assert!(ctx.borrow().parent.is_some());
     assert!(ctx.borrow().children.is_empty());
 
-    let stm_ctx = ctx.borrow().context.clone().get();
+    let stm_ctx = ctx.borrow().get_context().clone().get();
     assert_eq!(stm_ctx.len(), 4);
     assert_eq!(
         stm_ctx[0],

--- a/tests/loop_tests.rs
+++ b/tests/loop_tests.rs
@@ -152,85 +152,16 @@ fn loop_statements() {
     ];
     t.state.loop_statement(&loop_stmt, &block_state);
 
+    assert!(t.is_empty_error());
+    let main_ctx = block_state.borrow().get_context().get();
+    assert_eq!(main_ctx.len(), 17);
     assert!(block_state.borrow().parent.is_none());
-    assert_eq!(block_state.borrow().get_context().clone().get().len(), 0);
     assert!(block_state.borrow().parent.is_none());
     assert_eq!(block_state.borrow().children.len(), 1);
 
     let ctx = block_state.borrow().children[0].clone();
     assert!(ctx.borrow().parent.is_some());
     assert_eq!(ctx.borrow().children.len(), 2);
-
-    let stm_ctx = ctx.borrow().get_context().clone().get();
-    assert_eq!(stm_ctx.len(), 7);
-    assert_eq!(
-        stm_ctx[0],
-        SemanticStackContext::JumpTo {
-            label: String::from("loop_begin").into()
-        }
-    );
-    assert_eq!(
-        stm_ctx[1],
-        SemanticStackContext::SetLabel {
-            label: String::from("loop_begin").into()
-        }
-    );
-    assert_eq!(
-        stm_ctx[2],
-        SemanticStackContext::LetBinding {
-            let_decl: Value {
-                inner_name: "x.0".into(),
-                inner_type: Type::Primitive(PrimitiveTypes::Bool),
-                mutable: true,
-                alloca: false,
-                malloc: false
-            },
-            expr_result: ExpressionResult {
-                expr_type: Type::Primitive(PrimitiveTypes::Bool),
-                expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::Bool(false)),
-            },
-        }
-    );
-    assert_eq!(
-        stm_ctx[3],
-        SemanticStackContext::Binding {
-            val: Value {
-                inner_name: "x.0".into(),
-                inner_type: Type::Primitive(PrimitiveTypes::Bool),
-                mutable: true,
-                alloca: false,
-                malloc: false
-            },
-            expr_result: ExpressionResult {
-                expr_type: Type::Primitive(PrimitiveTypes::Bool),
-                expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::Bool(true)),
-            },
-        }
-    );
-    assert_eq!(
-        stm_ctx[4],
-        SemanticStackContext::Call {
-            call: Function {
-                inner_name: String::from("fn2").into(),
-                inner_type: Type::Primitive(PrimitiveTypes::U16),
-                parameters: vec![],
-            },
-            params: vec![],
-            register_number: 1,
-        }
-    );
-    assert_eq!(
-        stm_ctx[5],
-        SemanticStackContext::JumpTo {
-            label: String::from("loop_begin").into()
-        }
-    );
-    assert_eq!(
-        stm_ctx[6],
-        SemanticStackContext::SetLabel {
-            label: String::from("loop_end").into()
-        }
-    );
 
     let ch_ctx1 = ctx.borrow().children[0].clone();
     assert!(ch_ctx1.borrow().parent.is_some());
@@ -323,7 +254,87 @@ fn loop_statements() {
         }
     );
 
-    assert!(t.is_empty_error());
+    let stm_ctx = ctx.borrow().get_context().clone().get();
+    assert_eq!(stm_ctx.len(), 17);
+    assert_eq!(stm_ctx, main_ctx);
+    assert_eq!(
+        stm_ctx[0],
+        SemanticStackContext::JumpTo {
+            label: String::from("loop_begin").into()
+        }
+    );
+    assert_eq!(
+        stm_ctx[1],
+        SemanticStackContext::SetLabel {
+            label: String::from("loop_begin").into()
+        }
+    );
+    assert_eq!(
+        stm_ctx[2],
+        SemanticStackContext::LetBinding {
+            let_decl: Value {
+                inner_name: "x.0".into(),
+                inner_type: Type::Primitive(PrimitiveTypes::Bool),
+                mutable: true,
+                alloca: false,
+                malloc: false
+            },
+            expr_result: ExpressionResult {
+                expr_type: Type::Primitive(PrimitiveTypes::Bool),
+                expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::Bool(false)),
+            },
+        }
+    );
+    assert_eq!(
+        stm_ctx[3],
+        SemanticStackContext::Binding {
+            val: Value {
+                inner_name: "x.0".into(),
+                inner_type: Type::Primitive(PrimitiveTypes::Bool),
+                mutable: true,
+                alloca: false,
+                malloc: false
+            },
+            expr_result: ExpressionResult {
+                expr_type: Type::Primitive(PrimitiveTypes::Bool),
+                expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::Bool(true)),
+            },
+        }
+    );
+    assert_eq!(
+        stm_ctx[4],
+        SemanticStackContext::Call {
+            call: Function {
+                inner_name: String::from("fn2").into(),
+                inner_type: Type::Primitive(PrimitiveTypes::U16),
+                parameters: vec![],
+            },
+            params: vec![],
+            register_number: 1,
+        }
+    );
+    assert_eq!(stm_ctx[5], ctx1[0]);
+    assert_eq!(stm_ctx[6], ctx1[1]);
+    assert_eq!(stm_ctx[7], ctx1[2]);
+    assert_eq!(stm_ctx[8], ctx1[3]);
+    assert_eq!(stm_ctx[9], ctx1[4]);
+    assert_eq!(stm_ctx[10], ctx2[0]);
+    assert_eq!(stm_ctx[11], ctx2[1]);
+    assert_eq!(stm_ctx[12], ctx2[2]);
+    assert_eq!(stm_ctx[13], ctx2[3]);
+    assert_eq!(stm_ctx[14], ctx2[4]);
+    assert_eq!(
+        stm_ctx[15],
+        SemanticStackContext::JumpTo {
+            label: String::from("loop_begin").into()
+        }
+    );
+    assert_eq!(
+        stm_ctx[16],
+        SemanticStackContext::SetLabel {
+            label: String::from("loop_end").into()
+        }
+    );
 }
 
 #[test]
@@ -437,8 +448,9 @@ fn loop_statements_with_return_invocation() {
     let loop_stmt = [loop_body_let_binding, loop_body_return];
     t.state.loop_statement(&loop_stmt, &block_state);
 
+    let main_ctx = block_state.borrow().get_context().get();
+    assert_eq!(main_ctx.len(), 4);
     assert!(block_state.borrow().parent.is_none());
-    assert_eq!(block_state.borrow().get_context().clone().get().len(), 0);
     assert!(block_state.borrow().parent.is_none());
     assert_eq!(block_state.borrow().children.len(), 1);
 
@@ -448,6 +460,7 @@ fn loop_statements_with_return_invocation() {
 
     let stm_ctx = ctx.borrow().get_context().clone().get();
     assert_eq!(stm_ctx.len(), 4);
+    assert_eq!(stm_ctx, main_ctx);
     assert_eq!(
         stm_ctx[0],
         SemanticStackContext::JumpTo {

--- a/tests/main_tests.rs
+++ b/tests/main_tests.rs
@@ -150,7 +150,7 @@ fn main_run() {
     assert!(ch_ctx2.borrow().children.is_empty());
 
     // Semantic stack context for the block fn1
-    let st_ctx1 = ctx1.context.clone().get();
+    let st_ctx1 = ctx1.get_context().clone().get();
     assert_eq!(st_ctx1.len(), 4);
     assert_eq!(
         st_ctx1[0],
@@ -208,7 +208,7 @@ fn main_run() {
     );
 
     // Semantic stack context for the block fn2
-    let st_ctx2 = ctx2.context.clone().get();
+    let st_ctx2 = ctx2.get_context().clone().get();
     assert_eq!(st_ctx2.len(), 1);
     assert_eq!(
         st_ctx2[0],
@@ -220,7 +220,7 @@ fn main_run() {
         }
     );
 
-    let st_ch_ctx1 = ch_ctx1.borrow().context.clone().get();
+    let st_ch_ctx1 = ch_ctx1.borrow().get_context().clone().get();
     assert_eq!(st_ch_ctx1.len(), 5);
     assert_eq!(
         st_ch_ctx1[0],
@@ -264,7 +264,7 @@ fn main_run() {
         }
     );
 
-    let st_ch_ctx2 = ch_ctx2.borrow().context.clone().get();
+    let st_ch_ctx2 = ch_ctx2.borrow().get_context().clone().get();
     assert_eq!(st_ch_ctx2.len(), 5);
     assert_eq!(
         st_ch_ctx2[0],
@@ -406,7 +406,7 @@ fn expression_as_return() {
     assert!(ctx.parent.is_none());
 
     // Semantic stack context for the block
-    let st_ctx = ctx.context.clone().get();
+    let st_ctx = ctx.get_context().clone().get();
     assert_eq!(st_ctx.len(), 1);
     assert_eq!(
         st_ctx[0],
@@ -473,7 +473,7 @@ fn if_return_from_function() {
     assert!(children_ctx.parent.is_some());
 
     // Children semantic stack context for the block
-    let st_children_ctx = children_ctx.context.clone().get();
+    let st_children_ctx = children_ctx.get_context().clone().get();
     assert_eq!(st_children_ctx.len(), 4);
     assert_eq!(
         st_children_ctx[0],
@@ -509,7 +509,7 @@ fn if_return_from_function() {
     );
 
     // Semantic stack context for the block
-    let st_ctx = ctx.context.clone().get();
+    let st_ctx = ctx.get_context().clone().get();
     assert_eq!(st_ctx.len(), 1);
     assert_eq!(
         st_ctx[0],

--- a/tests/main_tests.rs
+++ b/tests/main_tests.rs
@@ -149,64 +149,6 @@ fn main_run() {
     assert!(ch_ctx2.borrow().parent.is_some());
     assert!(ch_ctx2.borrow().children.is_empty());
 
-    // Semantic stack context for the block fn1
-    let st_ctx1 = ctx1.get_context().clone().get();
-    assert_eq!(st_ctx1.len(), 4);
-    assert_eq!(
-        st_ctx1[0],
-        SemanticStackContext::LetBinding {
-            let_decl: Value {
-                inner_name: "x.0".into(),
-                inner_type: Type::Primitive(PrimitiveTypes::Bool),
-                mutable: true,
-                alloca: false,
-                malloc: false
-            },
-            expr_result: ExpressionResult {
-                expr_type: Type::Primitive(PrimitiveTypes::Bool),
-                expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::Bool(false)),
-            },
-        }
-    );
-    assert_eq!(
-        st_ctx1[1],
-        SemanticStackContext::Binding {
-            val: Value {
-                inner_name: "x.0".into(),
-                inner_type: Type::Primitive(PrimitiveTypes::Bool),
-                mutable: true,
-                alloca: false,
-                malloc: false
-            },
-            expr_result: ExpressionResult {
-                expr_type: Type::Primitive(PrimitiveTypes::Bool),
-                expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::Bool(true)),
-            },
-        }
-    );
-    assert_eq!(
-        st_ctx1[2],
-        SemanticStackContext::Call {
-            call: Function {
-                inner_name: String::from("fn2").into(),
-                inner_type: Type::Primitive(PrimitiveTypes::U16),
-                parameters: vec![],
-            },
-            params: vec![],
-            register_number: 1
-        }
-    );
-
-    assert_eq!(
-        st_ctx1[3],
-        SemanticStackContext::ExpressionFunctionReturn {
-            expr_result: ExpressionResult {
-                expr_type: Type::Primitive(PrimitiveTypes::Bool),
-                expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::Bool(true)),
-            }
-        }
-    );
-
     // Semantic stack context for the block fn2
     let st_ctx2 = ctx2.get_context().clone().get();
     assert_eq!(st_ctx2.len(), 1);
@@ -328,6 +270,73 @@ fn main_run() {
         st_global_context[3],
         SemanticStackContext::FunctionDeclaration {
             fn_decl: fn2.into()
+        }
+    );
+
+    // Semantic stack context for the block fn1
+    let st_ctx1 = ctx1.get_context().clone().get();
+    assert_eq!(st_ctx1.len(), 14);
+    assert_eq!(
+        st_ctx1[0],
+        SemanticStackContext::LetBinding {
+            let_decl: Value {
+                inner_name: "x.0".into(),
+                inner_type: Type::Primitive(PrimitiveTypes::Bool),
+                mutable: true,
+                alloca: false,
+                malloc: false
+            },
+            expr_result: ExpressionResult {
+                expr_type: Type::Primitive(PrimitiveTypes::Bool),
+                expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::Bool(false)),
+            },
+        }
+    );
+    assert_eq!(
+        st_ctx1[1],
+        SemanticStackContext::Binding {
+            val: Value {
+                inner_name: "x.0".into(),
+                inner_type: Type::Primitive(PrimitiveTypes::Bool),
+                mutable: true,
+                alloca: false,
+                malloc: false
+            },
+            expr_result: ExpressionResult {
+                expr_type: Type::Primitive(PrimitiveTypes::Bool),
+                expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::Bool(true)),
+            },
+        }
+    );
+    assert_eq!(
+        st_ctx1[2],
+        SemanticStackContext::Call {
+            call: Function {
+                inner_name: String::from("fn2").into(),
+                inner_type: Type::Primitive(PrimitiveTypes::U16),
+                parameters: vec![],
+            },
+            params: vec![],
+            register_number: 1
+        }
+    );
+    assert_eq!(st_ctx1[3], st_ch_ctx1[0]);
+    assert_eq!(st_ctx1[4], st_ch_ctx1[1]);
+    assert_eq!(st_ctx1[5], st_ch_ctx1[2]);
+    assert_eq!(st_ctx1[6], st_ch_ctx1[3]);
+    assert_eq!(st_ctx1[7], st_ch_ctx1[4]);
+    assert_eq!(st_ctx1[8], st_ch_ctx2[0]);
+    assert_eq!(st_ctx1[9], st_ch_ctx2[1]);
+    assert_eq!(st_ctx1[10], st_ch_ctx2[2]);
+    assert_eq!(st_ctx1[11], st_ch_ctx2[3]);
+    assert_eq!(st_ctx1[12], st_ch_ctx2[4]);
+    assert_eq!(
+        st_ctx1[13],
+        SemanticStackContext::ExpressionFunctionReturn {
+            expr_result: ExpressionResult {
+                expr_type: Type::Primitive(PrimitiveTypes::Bool),
+                expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::Bool(true)),
+            }
         }
     );
 }
@@ -509,10 +518,14 @@ fn if_return_from_function() {
     );
 
     // Semantic stack context for the block
-    let st_ctx = ctx.get_context().clone().get();
-    assert_eq!(st_ctx.len(), 1);
+    let st_ctx = ctx.get_context().get();
+    assert_eq!(st_ctx.len(), 5);
+    assert_eq!(st_ctx[0], st_children_ctx[0]);
+    assert_eq!(st_ctx[1], st_children_ctx[1]);
+    assert_eq!(st_ctx[2], st_children_ctx[2]);
+    assert_eq!(st_ctx[3], st_children_ctx[3]);
     assert_eq!(
-        st_ctx[0],
+        st_ctx[4],
         SemanticStackContext::ExpressionFunctionReturnWithLabel {
             expr_result: ExpressionResult {
                 expr_type: Type::Primitive(PrimitiveTypes::I8),

--- a/tests/state_tests.rs
+++ b/tests/state_tests.rs
@@ -51,7 +51,7 @@ fn block_state_fields() {
     assert!(!bst.manual_return);
     assert!(bst.parent.is_none());
     assert!(bst.children.is_empty());
-    assert_eq!(bst.context, SemanticStack::new());
+    assert_eq!(bst.get_context(), SemanticStack::new());
     bst.set_child(Rc::new(RefCell::new(BlockState::new(None))));
     assert_eq!(bst.children.len(), 1);
 

--- a/tests/state_tests.rs
+++ b/tests/state_tests.rs
@@ -1,5 +1,6 @@
 use semantic_analyzer::ast::{self, Ident};
 use semantic_analyzer::semantic::State;
+use semantic_analyzer::types::semantic::SemanticContext;
 use semantic_analyzer::types::{
     block_state::BlockState,
     semantic::SemanticStack,
@@ -221,4 +222,20 @@ fn block_state_last_register_inc() {
     assert_eq!(bst3.last_register_number, 1);
     // For grcov
     format!("{bst3:?}");
+}
+
+#[test]
+fn block_state_instructions_with_parent() {
+    let parent_bst = Rc::new(RefCell::new(BlockState::new(None)));
+    let mut bst = BlockState::new(Some(parent_bst.clone()));
+    let val = Value {
+        inner_name: String::from("x").into(),
+        inner_type: Type::Primitive(PrimitiveTypes::Ptr),
+        mutable: false,
+        alloca: false,
+        malloc: false,
+    };
+    bst.expression_value(val, 1);
+    let parent_ctx = parent_bst.borrow().get_context().get();
+    assert_eq!(parent_ctx.len(), 1);
 }


### PR DESCRIPTION
## Description

The current `BlockState` is represented as a tree with one parent and many children. It represents blocks as a tree with branches and leaves. Each block state has a `context` that contains `SemanticStack`. It means that all contexts also represented as a tree. Related to issue #16.

🔦  To simplify the fetching process for Codegen backends, there is an added the changes:
- [x] for the parent BlockState "flatten" all children's contexts. It means parent context will also include children's contexts. And it has linear representations. At the same time, it has children `BlockState` with their own context
- [x] root `BlockState` contains flattened linear context related to all children's `BlockState`  context.

### Tests

- [x] Added additional tests for all related flattened `BoclState` contexts.
- [x] Added tests for `BlockState` parent invokation.

### 🏦 `BlockState` changes

Added traits:
- `SemanticContext`
- `GlobalSemanticContext`

For `BlockState` trait `SemanticContext` implementation added invokcation for all parent `BlockState` nodes in context. It's guaranteed, that all parent context nodes have the same leaves as children. And `root` contains full representation of children's instructions.

