### PR TITLE
Feat: Function parameters init as variables

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-analyzer"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Evgeny Ukhanov <mrlsd@ya.ru>"]
 description = "Semantic analyzer library for compilers written in Rust for semantic analysis of programming languages AST"
 keywords = ["compiler", "semantic-analisis", "semantic-alalyzer", "compiler-design", "semantic"]
@@ -12,6 +12,10 @@ repository = "https://github.com/mrLSD/semantic-analyzer-rs"
 
 [lib]
 doctest = false
+
+#[lints.clippy]
+#pedantic = "deny"
+#nursery = "deny"
 
 [dependencies]
 nom_locate = "4.2"

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -33,6 +33,7 @@ impl GetName for ImportName<'_> {
 }
 
 impl<'a> ImportName<'a> {
+    #[must_use]
     pub const fn new(ident: Ident<'a>) -> Self {
         Self(ident)
     }
@@ -47,6 +48,7 @@ pub struct ConstantName<'a>(Ident<'a>);
 
 impl<'a> ConstantName<'a> {
     /// Init `ConstantName`, especially useful for testing
+    #[must_use]
     pub const fn new(name: Ident<'a>) -> Self {
         Self(name)
     }
@@ -69,6 +71,7 @@ impl GetName for ConstantName<'_> {
 pub struct FunctionName<'a>(Ident<'a>);
 
 impl<'a> FunctionName<'a> {
+    #[must_use]
     pub const fn new(name: Ident<'a>) -> Self {
         Self(name)
     }
@@ -92,6 +95,7 @@ impl<'a> ToString for FunctionName<'a> {
 pub struct ParameterName<'a>(Ident<'a>);
 
 impl<'a> ParameterName<'a> {
+    #[must_use]
     pub const fn new(name: Ident<'a>) -> Self {
         Self(name)
     }
@@ -112,6 +116,7 @@ impl ToString for ParameterName<'_> {
 pub struct ValueName<'a>(Ident<'a>);
 
 impl<'a> ValueName<'a> {
+    #[must_use]
     pub const fn new(name: Ident<'a>) -> Self {
         Self(name)
     }
@@ -138,16 +143,19 @@ impl CodeLocation {
     /// Initialize code location with:
     /// - `location` - line of source code
     /// - `offset` - position on the line of source code
+    #[must_use]
     pub const fn new(location: u32, offset: usize) -> Self {
         Self(location, offset)
     }
 
     /// Get location line in the source
+    #[must_use]
     pub const fn line(&self) -> u32 {
         self.0
     }
 
     /// Get location position on the line in the source
+    #[must_use]
     pub const fn offset(&self) -> usize {
         self.1
     }
@@ -383,6 +391,7 @@ pub enum PrimitiveValue {
 }
 
 impl PrimitiveValue {
+    #[must_use]
     pub const fn get_type(&self) -> Type<'_> {
         match self {
             Self::U8(_) => Type::Primitive(PrimitiveTypes::U8),
@@ -451,6 +460,8 @@ pub enum ExpressionOperations {
 }
 
 impl ExpressionOperations {
+    /// Get expression operation priority level
+    #[must_use]
     pub const fn priority(&self) -> u8 {
         match self {
             Self::Plus => 5,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(clippy::pedantic, clippy::nursery)]
+#![allow(clippy::module_name_repetitions)]
 //! # Semantic Analyzer
 //! The semantic analyzer consists of the following basic elements:
 //! - AST is an abstract syntax tree that implements a predefined set of

--- a/src/types/block_state.rs
+++ b/src/types/block_state.rs
@@ -49,6 +49,7 @@ pub struct BlockState {
 
 impl BlockState {
     /// Init block state with optional `parent` state
+    #[must_use]
     pub fn new(parent: Option<Rc<RefCell<Self>>>) -> Self {
         // Get values from parent
         let (last_register_number, inner_values_name, labels, manual_return) =
@@ -76,6 +77,7 @@ impl BlockState {
         }
     }
 
+    #[must_use]
     pub fn get_context(&self) -> SemanticStack {
         self.context.clone()
     }
@@ -95,7 +97,7 @@ impl BlockState {
     }
 
     /// Get child Block state
-    pub fn set_child(&mut self, child: Rc<RefCell<BlockState>>) {
+    pub fn set_child(&mut self, child: Rc<RefCell<Self>>) {
         self.children.push(child);
     }
 
@@ -108,6 +110,7 @@ impl BlockState {
     }
 
     /// Check is `inner_value_name` exist in current and parent states
+    #[must_use]
     pub fn is_inner_value_name_exist(&self, name: &InnerValueName) -> bool {
         if self.inner_values_name.contains(name) {
             return true;
@@ -119,6 +122,7 @@ impl BlockState {
 
     /// Get `Value` by value name from current state.
     /// If not found on current state - recursively find in parent states.
+    #[must_use]
     pub fn get_value_name(&self, name: &ValueName) -> Option<Value> {
         if let Some(val) = self.values.get(name) {
             return Some(val.clone());
@@ -129,6 +133,7 @@ impl BlockState {
     }
 
     /// Check is label name exist in current and parent states
+    #[must_use]
     pub fn is_label_name_exist(&self, name: &LabelName) -> bool {
         if self.labels.contains(name) {
             return true;
@@ -147,10 +152,11 @@ impl BlockState {
     }
 
     /// Set attribute counter - increment, if counter exist.
+    #[must_use]
     pub fn set_attr_counter(val: &str) -> String {
         let val_attr: Vec<&str> = val.split('.').collect();
         if val_attr.len() == 2 {
-            let i: u64 = val_attr[1].parse().expect("expect integer");
+            let i: u64 = val_attr[1].parse().unwrap_or_default();
             format!("{}.{:?}", val_attr[0], i + 1)
         } else {
             format!("{}.0", val_attr[0])
@@ -179,6 +185,7 @@ impl BlockState {
 
     /// Get next `inner_value_name` by name counter for current and
     /// parent states. The `inner_value_name` should always be unique.
+    #[must_use]
     pub fn get_next_inner_name(&self, val: &InnerValueName) -> InnerValueName {
         // Increment inner value name counter for shadowed variable
         let name: InnerValueName = Self::set_attr_counter(&val.to_string()).into();
@@ -225,7 +232,7 @@ impl SemanticContext for BlockState {
         if let Some(parent) = &self.parent {
             parent
                 .borrow_mut()
-                .expression_struct_value(expression, index, register_number)
+                .expression_struct_value(expression, index, register_number);
         }
     }
 

--- a/src/types/block_state.rs
+++ b/src/types/block_state.rs
@@ -2,7 +2,7 @@
 //! Block state Semantic types.
 
 use super::semantic::SemanticStack;
-use super::{Constant, Function, InnerValueName, LabelName, Value, ValueName};
+use super::{Constant, Function, FunctionParameter, InnerValueName, LabelName, Value, ValueName};
 use crate::types::condition::{Condition, LogicCondition};
 use crate::types::expression::{ExpressionOperations, ExpressionResult};
 use crate::types::semantic::SemanticContext;
@@ -392,6 +392,13 @@ impl SemanticContext for BlockState {
             parent
                 .borrow_mut()
                 .if_condition_logic(label_if_begin, label_if_end, result_register);
+        }
+    }
+
+    fn function_arg(&mut self, value: Value, func_arg: FunctionParameter) {
+        self.context.function_arg(value.clone(), func_arg.clone());
+        if let Some(parent) = &self.parent {
+            parent.borrow_mut().function_arg(value, func_arg);
         }
     }
 }

--- a/src/types/error.rs
+++ b/src/types/error.rs
@@ -31,6 +31,7 @@ pub enum StateErrorKind {
     ForbiddenCodeAfterReturnDeprecated,
     ForbiddenCodeAfterContinueDeprecated,
     ForbiddenCodeAfterBreakDeprecated,
+    FunctionArgumentNameDuplicated,
 }
 
 /// State error location. Useful to determine location of error

--- a/src/types/error.rs
+++ b/src/types/error.rs
@@ -50,6 +50,7 @@ pub struct StateErrorResult {
 }
 
 impl StateErrorResult {
+    #[must_use]
     pub const fn new(kind: StateErrorKind, value: String, location: CodeLocation) -> Self {
         Self {
             kind,
@@ -60,8 +61,8 @@ impl StateErrorResult {
 }
 
 impl StateErrorResult {
-    #[allow(dead_code)]
     /// Get state trace data from error result as string
+    #[must_use]
     pub fn trace_state(&self) -> String {
         format!(
             "[{:?}] for value {:?} at: {:?}:{:?}",

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -418,7 +418,7 @@ impl ToString for PrimitiveValue {
             Self::F64(val) => val.clone().to_string(),
             Self::Bool(val) => val.to_string(),
             Self::String(s) => s.clone(),
-            Self::Char(c) => format!("{}", c),
+            Self::Char(c) => format!("{c}"),
             Self::Ptr => "ptr".to_string(),
             Self::None => "None".to_string(),
         }

--- a/src/types/semantic.rs
+++ b/src/types/semantic.rs
@@ -70,6 +70,7 @@ pub struct SemanticStack(Vec<SemanticStackContext>);
 
 impl SemanticStack {
     /// Init Semantic stack
+    #[must_use]
     pub fn new() -> Self {
         Self::default()
     }
@@ -80,6 +81,7 @@ impl SemanticStack {
     }
 
     /// Get all context stack data as array data
+    #[must_use]
     pub fn get(self) -> Vec<SemanticStackContext> {
         self.0
     }
@@ -320,9 +322,9 @@ impl SemanticContext for SemanticStack {
     /// Result of calculation stored to `register_number`.
     ///
     /// ## Parameters
-    /// - left_register_result - result of left condition
-    /// - right_register_result - result of right condition
-    /// - register_number - register to store instruction result
+    /// - `left_register_result` - result of left condition
+    /// - `right_register_result` - result of right condition
+    /// - `register_number` - register to store instruction result
     fn logic_condition(
         &mut self,
         logic_condition: LogicCondition,

--- a/src/types/semantic.rs
+++ b/src/types/semantic.rs
@@ -5,7 +5,7 @@
 use super::condition::{Condition, LogicCondition};
 use super::expression::{ExpressionOperations, ExpressionResult};
 use super::types::StructTypes;
-use super::{Constant, Function, FunctionStatement, LabelName, Value};
+use super::{Constant, Function, FunctionParameter, FunctionStatement, LabelName, Value};
 
 pub trait GlobalSemanticContext {
     fn function_declaration(&mut self, fn_decl: FunctionStatement);
@@ -60,6 +60,7 @@ pub trait SemanticContext {
         label_if_end: LabelName,
         result_register: u64,
     );
+    fn function_arg(&mut self, value: Value, func_arg: FunctionParameter);
 }
 
 /// # Semantic stack
@@ -363,6 +364,16 @@ impl SemanticContext for SemanticStack {
             result_register,
         });
     }
+
+    /// Push Context to the stack as `function argument` data.
+    /// This instruction should allocate pointer (if argument type is
+    /// not Ptr) and store argument value to the pointer.
+    ///
+    /// ## Parameters
+    /// - `func_arg` - function parameter data
+    fn function_arg(&mut self, value: Value, func_arg: FunctionParameter) {
+        self.push(SemanticStackContext::FunctionArg { value, func_arg });
+    }
 }
 
 /// # Semantic stack Context
@@ -447,5 +458,9 @@ pub enum SemanticStackContext {
         label_if_begin: LabelName,
         label_if_end: LabelName,
         result_register: u64,
+    },
+    FunctionArg {
+        value: Value,
+        func_arg: FunctionParameter,
     },
 }

--- a/src/types/types.rs
+++ b/src/types/types.rs
@@ -56,11 +56,13 @@ pub enum Type {
 
 impl Type {
     /// Get type name
+    #[must_use]
     pub fn name(&self) -> TypeName {
         self.to_string().into()
     }
 
     /// Get structure type if it is
+    #[must_use]
     pub fn get_struct(&self) -> Option<StructTypes> {
         match self {
             Self::Struct(ty) => Some(ty.clone()),
@@ -231,7 +233,7 @@ impl From<ast::StructTypes<'_>> for StructTypes {
                 for (index, val) in value.attributes.iter().enumerate() {
                     let name = (*val.attr_name.fragment()).to_string();
                     let mut v: StructAttributeType = val.clone().into();
-                    v.attr_index = index as u32;
+                    v.attr_index = u32::try_from(index).unwrap_or_default();
                     res.insert(name.into(), v);
                 }
                 res

--- a/tests/if_tests.rs
+++ b/tests/if_tests.rs
@@ -305,7 +305,7 @@ fn check_if_and_else_if_statement_duplicate() {
         else_statement: Some(ast::IfBodyStatements::If(vec![])),
         else_if_statement: Some(Box::new(if_else_stmt)),
     };
-    t.state.if_condition(&if_stmt, &block_state, None, None);
+    t.state.if_condition(&if_stmt, &block_state, &None, None);
     assert!(t.check_errors_len(1), "Errors: {:?}", t.state.errors.len());
     assert!(
         t.check_error(StateErrorKind::IfElseDuplicated),
@@ -773,9 +773,10 @@ fn else_if_statement() {
     t.state.if_condition(
         &if_stmt,
         &block_state,
-        None,
+        &None,
         Some((&label_loop_begin, &label_loop_end)),
     );
+    println!("{:#?}", t.state.errors);
     assert!(t.is_empty_error());
 
     let main_ctx = block_state.borrow().get_context().clone().get();
@@ -981,7 +982,7 @@ fn if_body_statements() {
     t.state.if_condition(
         &if_stmt,
         &block_state,
-        None,
+        &None,
         Some((&label_loop_begin, &label_loop_end)),
     );
     assert!(t.is_empty_error());
@@ -1268,7 +1269,7 @@ fn if_loop_body_statements() {
     t.state.if_condition(
         &if_stmt,
         &block_state,
-        None,
+        &None,
         Some((&label_loop_begin, &label_loop_end)),
     );
     assert!(t.is_empty_error());
@@ -1495,7 +1496,7 @@ fn if_loop_body_instructions_after_return() {
     t.state.if_condition(
         &if_stmt,
         &block_state,
-        None,
+        &None,
         Some((&label_loop_begin, &label_loop_end)),
     );
 
@@ -1547,7 +1548,7 @@ fn else_if_loop_body_instructions_after_return() {
     t.state.if_condition(
         &if_stmt,
         &block_state,
-        None,
+        &None,
         Some((&label_loop_begin, &label_loop_end)),
     );
 
@@ -1596,7 +1597,7 @@ fn if_body_instructions_after_return() {
     t.state.if_condition(
         &if_stmt,
         &block_state,
-        None,
+        &None,
         Some((&label_loop_begin, &label_loop_end)),
     );
 
@@ -1648,7 +1649,7 @@ fn if_else_body_instructions_after_return() {
     t.state.if_condition(
         &if_stmt,
         &block_state,
-        None,
+        &None,
         Some((&label_loop_begin, &label_loop_end)),
     );
 
@@ -1694,7 +1695,7 @@ fn if_loop_body_instructions_after_break() {
     t.state.if_condition(
         &if_stmt,
         &block_state,
-        None,
+        &None,
         Some((&label_loop_begin, &label_loop_end)),
     );
     assert!(t.check_errors_len(1), "Errors: {:?}", t.state.errors.len());
@@ -1739,7 +1740,7 @@ fn if_loop_body_instructions_after_continue() {
     t.state.if_condition(
         &if_stmt,
         &block_state,
-        None,
+        &None,
         Some((&label_loop_begin, &label_loop_end)),
     );
     assert!(t.check_errors_len(1), "Errors: {:?}", t.state.errors.len());

--- a/tests/state_tests.rs
+++ b/tests/state_tests.rs
@@ -9,8 +9,8 @@ use semantic_analyzer::types::{
     block_state::BlockState,
     semantic::SemanticStack,
     types::{PrimitiveTypes, Type},
-    Constant, ConstantExpression, ConstantValue, Function, InnerValueName, LabelName, Value,
-    ValueName,
+    Constant, ConstantExpression, ConstantValue, Function, FunctionParameter, InnerValueName,
+    LabelName, Value, ValueName,
 };
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -277,7 +277,12 @@ fn block_state_instructions_with_parent() {
     let logic_condition = LogicCondition::And;
     bst.logic_condition(logic_condition, 1, 2, 3);
     bst.if_condition_logic(label.clone(), label, 1);
+    let func_arg = FunctionParameter {
+        name: ast::ParameterName::new(Ident::new("x")).into(),
+        parameter_type: Type::Primitive(PrimitiveTypes::Ptr),
+    };
+    bst.function_arg(val, func_arg);
 
     let parent_ctx = parent_bst.borrow().get_context().get();
-    assert_eq!(parent_ctx.len(), 16);
+    assert_eq!(parent_ctx.len(), 17);
 }


### PR DESCRIPTION
## Description

⏲️  Currently, function parameters are not interpreted as variables, and it means that `Codegen` should operate with that to the own choice. Solve:
- [x] #18 

🍰  Added function parameters as variables to `BlockState` with 🌷 additional instruction `FunctionArg` to `SemanticStack` for allocation 🎇 and bind explicitly in `Codegen` backend. 

### 💡 Tests

Extended tests, that covers new instructions and `func-params` additions.

### 💪 Clippy

Increased clippy level to most maximum and fixed all clippy-related issues 🍾.


