### PR TITLE
Feat: refactore extend expression

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-analyzer"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Evgeny Ukhanov <mrlsd@ya.ru>"]
 description = "Semantic analyzer library for compilers written in Rust for semantic analysis of programming languages AST"
 keywords = ["compiler", "semantic-analisis", "semantic-alalyzer", "compiler-design", "semantic"]
@@ -20,7 +20,7 @@ doctest = false
 
 [dependencies]
 nom_locate = "4.2"
-serde = { version =  "1", features = ["derive"], optional = true }
+serde = { version = "1", features = ["derive"], optional = true }
 
 [dev-dependencies]
 serde_json = "1"

--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@
 Semantic analyzer is an open source semantic analyzer for programming languages 
 that makes it easy to build your own efficient compilers with extensibility in mind.
 
-## 🌀 What is the library for and what tasks does it solve
+## 🌀 What the library is for and what tasks it solves
 
 Creating a compilers for a programming language is process that involves several key 
-stages. Most commonly it is:
+stages. Most commonly they are:
 
 ▶️ **Lexical Analysis (Lexer)**: This stage involves breaking down the input stream 
 of characters into a series of tokens. Tokens are the atomic elements of the programming language, such as identifiers, keywords, operators, etc.
@@ -32,7 +32,7 @@ This can include dead code elimination, expression simplification, etc.
 ▶️ **Code Generation**: This is the final stage where the compiler transforms the optimized intermediate representation (IR) into 
 machine code specific to the target architecture.
 
-This library represent **Semantic Analysis** stage.
+This library represents **Semantic Analysis** stage.
 
 ### 🌻 Features
 
@@ -122,7 +122,7 @@ The ability to implement custom instructions for these custom expressions in the
 ## 🛋️ Examples
 
 - 🔎 There is the example implementation separate project [💾 Toy Codegen](https://github.com/mrLSD/toy-codegen).
-The project uses the `SemanticStack` results and converts them into **Code Generation** logic. Which clearly shows the 
+The project uses the `SemanticStack` results and converts them into **Code Generation** logic which clearly shows the 
 possibilities of using the results of the `semantic-analyzer-rs` `SemanticStackContext` results. LLVM is used as a 
 backend, [inkwell](https://github.com/TheDan64/inkwell) as a library for LLVM codegen, and compiled into an executable 
 program. The source of data is the AST structure itself.
@@ -136,7 +136,7 @@ Available library rust features:
   nuance is that any library that implements `Serde` can act as a 
   serializer `codec`. For example formats: `json`, `toml`, `yaml`, 
   `binary`, and many others that can use `serde` library.
-  The main entities, which apply the `codec` feature is:
+  The main entities, which apply the `codec` feature are:
   - [x] `AST` ↪️ AST data source can be presented with serialized source.
     This is especially useful for designing and testing `Codegen`, AST data 
     transfer pipeline, and also for use as a data generation source for 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -24,7 +24,7 @@ pub struct Ident<'a>(LocatedSpan<&'a str>);
 /// Ident methods mirroring `LocatedSpan`
 impl<'a> Ident<'a> {
     #[must_use]
-    pub fn new(ident: &'a str) -> Ident<'a> {
+    pub fn new(ident: &'a str) -> Self {
         Self(LocatedSpan::new(ident))
     }
 
@@ -51,7 +51,7 @@ impl<'a> std::fmt::Display for Ident<'a> {
 }
 
 impl<'a> From<&'a str> for Ident<'a> {
-    fn from(value: &'a str) -> Ident<'a> {
+    fn from(value: &'a str) -> Self {
         Ident::new(value)
     }
 }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -3,7 +3,7 @@
 //! represent full cycle and aspects of the programming language, and
 //! represent `Turing-complete` state machine.
 
-use crate::types::semantic::ExtendedExpression;
+use crate::types::semantic::{ExtendedExpression, SemanticContextInstruction};
 use nom_locate::LocatedSpan;
 #[cfg(feature = "codec")]
 use serde::{
@@ -11,6 +11,8 @@ use serde::{
     ser::{SerializeStruct, Serializer},
     Deserialize, Serialize,
 };
+use std::convert::Infallible;
+use std::marker::PhantomData;
 
 /// Max priority level fpr expressions operations
 pub const MAX_PRIORITY_LEVEL_FOR_EXPRESSIONS: u8 = 9;
@@ -520,7 +522,7 @@ pub struct FunctionParameter<'a> {
 /// function body.
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "codec", derive(Serialize, Deserialize))]
-pub struct FunctionStatement<'a, E: ExtendedExpression> {
+pub struct FunctionStatement<'a, I: SemanticContextInstruction, E: ExtendedExpression<I>> {
     /// Function name
     #[cfg_attr(feature = "codec", serde(borrow))]
     pub name: FunctionName<'a>,
@@ -529,16 +531,39 @@ pub struct FunctionStatement<'a, E: ExtendedExpression> {
     /// Function result type
     pub result_type: Type<'a>,
     /// Function body
-    pub body: Vec<BodyStatement<'a, E>>,
+    pub body: Vec<BodyStatement<'a, I, E>>,
+    _marker: PhantomData<I>,
 }
 
-impl<E: ExtendedExpression> GetLocation for FunctionStatement<'_, E> {
+impl<'a, I: SemanticContextInstruction, E: ExtendedExpression<I>> FunctionStatement<'a, I, E> {
+    #[must_use]
+    pub fn new(
+        name: FunctionName<'a>,
+        parameters: Vec<FunctionParameter<'a>>,
+        result_type: Type<'a>,
+        body: Vec<BodyStatement<'a, I, E>>,
+    ) -> Self {
+        Self {
+            name,
+            parameters,
+            result_type,
+            body,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<I: SemanticContextInstruction, E: ExtendedExpression<I>> GetLocation
+    for FunctionStatement<'_, I, E>
+{
     fn location(&self) -> CodeLocation {
         self.name.location()
     }
 }
 
-impl<E: ExtendedExpression> GetName for FunctionStatement<'_, E> {
+impl<I: SemanticContextInstruction, E: ExtendedExpression<I>> GetName
+    for FunctionStatement<'_, I, E>
+{
     fn name(&self) -> String {
         (*self.name.0.fragment()).to_string()
     }
@@ -609,20 +634,22 @@ impl PrimitiveValue {
     derive(Serialize, Deserialize),
     serde(tag = "type", content = "content")
 )]
-pub enum ExpressionValue<'a, E: ExtendedExpression> {
+pub enum ExpressionValue<'a, I: SemanticContextInstruction, E: ExtendedExpression<I>> {
     /// Value name of expression
     #[cfg_attr(feature = "codec", serde(borrow))]
     ValueName(ValueName<'a>),
     /// Primitive value of expression (like numbers etc.)
     PrimitiveValue(PrimitiveValue),
     /// Function call (with parameters) of expression
-    FunctionCall(FunctionCall<'a, E>),
+    FunctionCall(FunctionCall<'a, I, E>),
     /// Value of expression based on `Struct` types.
     StructValue(ExpressionStructValue<'a>),
     /// Expression representation (sub branch)
-    Expression(Box<Expression<'a, E>>),
+    Expression(Box<Expression<'a, I, E>>),
     /// Extended expression
     ExtendedExpression(Box<E>),
+    #[cfg_attr(feature = "codec", serde(skip))]
+    _Marker(Infallible, PhantomData<I>),
 }
 
 /// `ExpressionOperations` expression operation element of AST.
@@ -682,15 +709,15 @@ impl ExpressionOperations {
 /// with expression operations.
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "codec", derive(Serialize, Deserialize))]
-pub struct Expression<'a, E: ExtendedExpression> {
+pub struct Expression<'a, I: SemanticContextInstruction, E: ExtendedExpression<I>> {
     /// Expression value itself
     #[cfg_attr(feature = "codec", serde(borrow))]
-    pub expression_value: ExpressionValue<'a, E>,
+    pub expression_value: ExpressionValue<'a, I, E>,
     /// Optional expression operation with other expression value
-    pub operation: Option<(ExpressionOperations, Box<Expression<'a, E>>)>,
+    pub operation: Option<(ExpressionOperations, Box<Expression<'a, I, E>>)>,
 }
 
-impl<E: ExtendedExpression> GetLocation for Expression<'_, E> {
+impl<I: SemanticContextInstruction, E: ExtendedExpression<I>> GetLocation for Expression<'_, I, E> {
     fn location(&self) -> CodeLocation {
         // TODO: extend it
         CodeLocation::new(1, 0)
@@ -701,7 +728,7 @@ impl<E: ExtendedExpression> GetLocation for Expression<'_, E> {
 /// for `values` declarations.
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "codec", derive(Serialize, Deserialize), serde(tag = "type"))]
-pub struct LetBinding<'a, E: ExtendedExpression> {
+pub struct LetBinding<'a, I: SemanticContextInstruction, E: ExtendedExpression<I>> {
     /// Value name of let binding
     #[cfg_attr(feature = "codec", serde(borrow))]
     pub name: ValueName<'a>,
@@ -710,16 +737,16 @@ pub struct LetBinding<'a, E: ExtendedExpression> {
     /// Optional type of value
     pub value_type: Option<Type<'a>>,
     /// Value expression to bind as result of let bending
-    pub value: Box<Expression<'a, E>>,
+    pub value: Box<Expression<'a, I, E>>,
 }
 
-impl<E: ExtendedExpression> GetLocation for LetBinding<'_, E> {
+impl<I: SemanticContextInstruction, E: ExtendedExpression<I>> GetLocation for LetBinding<'_, I, E> {
     fn location(&self) -> CodeLocation {
         self.name.location()
     }
 }
 
-impl<E: ExtendedExpression> GetName for LetBinding<'_, E> {
+impl<I: SemanticContextInstruction, E: ExtendedExpression<I>> GetName for LetBinding<'_, I, E> {
     fn name(&self) -> String {
         self.name.0.to_string()
     }
@@ -730,21 +757,21 @@ impl<E: ExtendedExpression> GetName for LetBinding<'_, E> {
 /// declared values.
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "codec", derive(Serialize, Deserialize))]
-pub struct Binding<'a, E: ExtendedExpression> {
+pub struct Binding<'a, I: SemanticContextInstruction, E: ExtendedExpression<I>> {
     /// Binding value name
     #[cfg_attr(feature = "codec", serde(borrow))]
     pub name: ValueName<'a>,
     /// Value expression as result of binding
-    pub value: Box<Expression<'a, E>>,
+    pub value: Box<Expression<'a, I, E>>,
 }
 
-impl<E: ExtendedExpression> GetLocation for Binding<'_, E> {
+impl<I: SemanticContextInstruction, E: ExtendedExpression<I>> GetLocation for Binding<'_, I, E> {
     fn location(&self) -> CodeLocation {
         self.name.location()
     }
 }
 
-impl<E: ExtendedExpression> GetName for Binding<'_, E> {
+impl<I: SemanticContextInstruction, E: ExtendedExpression<I>> GetName for Binding<'_, I, E> {
     fn name(&self) -> String {
         self.name.0.to_string()
     }
@@ -754,21 +781,23 @@ impl<E: ExtendedExpression> GetName for Binding<'_, E> {
 /// Basic entity for function call representation.
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "codec", derive(Serialize, Deserialize))]
-pub struct FunctionCall<'a, E: ExtendedExpression> {
+pub struct FunctionCall<'a, I: SemanticContextInstruction, E: ExtendedExpression<I>> {
     /// Function name of called function
     #[cfg_attr(feature = "codec", serde(borrow))]
     pub name: FunctionName<'a>,
     /// Function parameters, represented through expression
-    pub parameters: Vec<Expression<'a, E>>,
+    pub parameters: Vec<Expression<'a, I, E>>,
 }
 
-impl<E: ExtendedExpression> GetLocation for FunctionCall<'_, E> {
+impl<I: SemanticContextInstruction, E: ExtendedExpression<I>> GetLocation
+    for FunctionCall<'_, I, E>
+{
     fn location(&self) -> CodeLocation {
         self.name.location()
     }
 }
 
-impl<E: ExtendedExpression> GetName for FunctionCall<'_, E> {
+impl<I: SemanticContextInstruction, E: ExtendedExpression<I>> GetName for FunctionCall<'_, I, E> {
     fn name(&self) -> String {
         (*self.name.0.fragment()).to_string()
     }
@@ -810,14 +839,14 @@ pub enum LogicCondition {
 /// It contains condition between twe expressions.
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "codec", derive(Serialize, Deserialize))]
-pub struct ExpressionCondition<'a, E: ExtendedExpression> {
+pub struct ExpressionCondition<'a, I: SemanticContextInstruction, E: ExtendedExpression<I>> {
     /// Left expression
     #[cfg_attr(feature = "codec", serde(borrow))]
-    pub left: Expression<'a, E>,
+    pub left: Expression<'a, I, E>,
     /// Condition between left and right expressions
     pub condition: Condition,
     /// Right expression
-    pub right: Expression<'a, E>,
+    pub right: Expression<'a, I, E>,
 }
 
 /// # Logic expression condition
@@ -829,12 +858,12 @@ pub struct ExpressionCondition<'a, E: ExtendedExpression> {
 /// expressions logic conditions.
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "codec", derive(Serialize, Deserialize))]
-pub struct ExpressionLogicCondition<'a, E: ExtendedExpression> {
+pub struct ExpressionLogicCondition<'a, I: SemanticContextInstruction, E: ExtendedExpression<I>> {
     /// Left expression condition
     #[cfg_attr(feature = "codec", serde(borrow))]
-    pub left: ExpressionCondition<'a, E>,
+    pub left: ExpressionCondition<'a, I, E>,
     /// Optional right side contain logic operation to other `ExpressionLogicCondition`
-    pub right: Option<(LogicCondition, Box<ExpressionLogicCondition<'a, E>>)>,
+    pub right: Option<(LogicCondition, Box<ExpressionLogicCondition<'a, I, E>>)>,
 }
 
 /// `IfCondition` if-condition control flow element of AST.
@@ -847,12 +876,12 @@ pub struct ExpressionLogicCondition<'a, E: ExtendedExpression> {
     derive(Serialize, Deserialize),
     serde(tag = "type", content = "content")
 )]
-pub enum IfCondition<'a, E: ExtendedExpression> {
+pub enum IfCondition<'a, I: SemanticContextInstruction, E: ExtendedExpression<I>> {
     /// Single if condition based on expression
     #[cfg_attr(feature = "codec", serde(borrow))]
-    Single(Expression<'a, E>),
+    Single(Expression<'a, I, E>),
     /// Logic expression condition tree
-    Logic(ExpressionLogicCondition<'a, E>),
+    Logic(ExpressionLogicCondition<'a, I, E>),
 }
 
 /// `IfStatement` if statement AST element.
@@ -863,19 +892,21 @@ pub enum IfCondition<'a, E: ExtendedExpression> {
 /// - Else-if-body statement - body of else-if-condition success
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "codec", derive(Serialize, Deserialize))]
-pub struct IfStatement<'a, E: ExtendedExpression> {
+pub struct IfStatement<'a, I: SemanticContextInstruction, E: ExtendedExpression<I>> {
     /// If-condition
     #[cfg_attr(feature = "codec", serde(borrow))]
-    pub condition: IfCondition<'a, E>,
+    pub condition: IfCondition<'a, I, E>,
     /// If-body statement - body of if-condition success
-    pub body: IfBodyStatements<'a, E>,
+    pub body: IfBodyStatements<'a, I, E>,
     /// If-else-body statement - body of else-condition success
-    pub else_statement: Option<IfBodyStatements<'a, E>>,
+    pub else_statement: Option<IfBodyStatements<'a, I, E>>,
     /// Else-if-body statement - body of else-if-condition success
-    pub else_if_statement: Option<Box<IfStatement<'a, E>>>,
+    pub else_if_statement: Option<Box<IfStatement<'a, I, E>>>,
 }
 
-impl<E: ExtendedExpression> GetLocation for IfStatement<'_, E> {
+impl<I: SemanticContextInstruction, E: ExtendedExpression<I>> GetLocation
+    for IfStatement<'_, I, E>
+{
     fn location(&self) -> CodeLocation {
         // TODO
         CodeLocation::new(1, 0)
@@ -890,22 +921,22 @@ impl<E: ExtendedExpression> GetLocation for IfStatement<'_, E> {
     derive(Serialize, Deserialize),
     serde(tag = "type", content = "content")
 )]
-pub enum BodyStatement<'a, E: ExtendedExpression> {
+pub enum BodyStatement<'a, I: SemanticContextInstruction, E: ExtendedExpression<I>> {
     /// Let-binding function declaration
     #[cfg_attr(feature = "codec", serde(borrow))]
-    LetBinding(LetBinding<'a, E>),
+    LetBinding(LetBinding<'a, I, E>),
     /// Binding function declaration
-    Binding(Binding<'a, E>),
+    Binding(Binding<'a, I, E>),
     /// Function call
-    FunctionCall(FunctionCall<'a, E>),
+    FunctionCall(FunctionCall<'a, I, E>),
     /// If-condition control flow statement
-    If(IfStatement<'a, E>),
+    If(IfStatement<'a, I, E>),
     /// Loop control flow statement
-    Loop(Vec<LoopBodyStatement<'a, E>>),
+    Loop(Vec<LoopBodyStatement<'a, I, E>>),
     /// Expression statement
-    Expression(Expression<'a, E>),
+    Expression(Expression<'a, I, E>),
     /// Return statement
-    Return(Expression<'a, E>),
+    Return(Expression<'a, I, E>),
 }
 
 /// `IfBodyStatement` statement of if-body elements tree of AST.
@@ -916,14 +947,14 @@ pub enum BodyStatement<'a, E: ExtendedExpression> {
     derive(Serialize, Deserialize),
     serde(tag = "type", content = "content")
 )]
-pub enum IfBodyStatement<'a, E: ExtendedExpression> {
+pub enum IfBodyStatement<'a, I: SemanticContextInstruction, E: ExtendedExpression<I>> {
     #[cfg_attr(feature = "codec", serde(borrow))]
-    LetBinding(LetBinding<'a, E>),
-    Binding(Binding<'a, E>),
-    FunctionCall(FunctionCall<'a, E>),
-    If(IfStatement<'a, E>),
-    Loop(Vec<LoopBodyStatement<'a, E>>),
-    Return(Expression<'a, E>),
+    LetBinding(LetBinding<'a, I, E>),
+    Binding(Binding<'a, I, E>),
+    FunctionCall(FunctionCall<'a, I, E>),
+    If(IfStatement<'a, I, E>),
+    Loop(Vec<LoopBodyStatement<'a, I, E>>),
+    Return(Expression<'a, I, E>),
 }
 
 /// `IfLoopBodyStatement` statement of loop-if-body elements tree of AST.
@@ -931,14 +962,14 @@ pub enum IfBodyStatement<'a, E: ExtendedExpression> {
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "codec", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "codec", serde(tag = "type", content = "content"))]
-pub enum IfLoopBodyStatement<'a, E: ExtendedExpression> {
+pub enum IfLoopBodyStatement<'a, I: SemanticContextInstruction, E: ExtendedExpression<I>> {
     #[cfg_attr(feature = "codec", serde(borrow))]
-    LetBinding(LetBinding<'a, E>),
-    Binding(Binding<'a, E>),
-    FunctionCall(FunctionCall<'a, E>),
-    If(IfStatement<'a, E>),
-    Loop(Vec<LoopBodyStatement<'a, E>>),
-    Return(Expression<'a, E>),
+    LetBinding(LetBinding<'a, I, E>),
+    Binding(Binding<'a, I, E>),
+    FunctionCall(FunctionCall<'a, I, E>),
+    If(IfStatement<'a, I, E>),
+    Loop(Vec<LoopBodyStatement<'a, I, E>>),
+    Return(Expression<'a, I, E>),
     Break,
     Continue,
 }
@@ -951,10 +982,10 @@ pub enum IfLoopBodyStatement<'a, E: ExtendedExpression> {
     derive(Serialize, Deserialize),
     serde(tag = "type", content = "content")
 )]
-pub enum IfBodyStatements<'a, E: ExtendedExpression> {
+pub enum IfBodyStatements<'a, I: SemanticContextInstruction, E: ExtendedExpression<I>> {
     #[cfg_attr(feature = "codec", serde(borrow))]
-    If(Vec<IfBodyStatement<'a, E>>),
-    Loop(Vec<IfLoopBodyStatement<'a, E>>),
+    If(Vec<IfBodyStatement<'a, I, E>>),
+    Loop(Vec<IfLoopBodyStatement<'a, I, E>>),
 }
 
 /// `LoopBodyStatement` statement of loop-body elements tree of AST.
@@ -965,14 +996,14 @@ pub enum IfBodyStatements<'a, E: ExtendedExpression> {
     derive(Serialize, Deserialize),
     serde(tag = "type", content = "content")
 )]
-pub enum LoopBodyStatement<'a, E: ExtendedExpression> {
+pub enum LoopBodyStatement<'a, I: SemanticContextInstruction, E: ExtendedExpression<I>> {
     #[cfg_attr(feature = "codec", serde(borrow))]
-    LetBinding(LetBinding<'a, E>),
-    Binding(Binding<'a, E>),
-    FunctionCall(FunctionCall<'a, E>),
-    If(IfStatement<'a, E>),
-    Loop(Vec<LoopBodyStatement<'a, E>>),
-    Return(Expression<'a, E>),
+    LetBinding(LetBinding<'a, I, E>),
+    Binding(Binding<'a, I, E>),
+    FunctionCall(FunctionCall<'a, I, E>),
+    If(IfStatement<'a, I, E>),
+    Loop(Vec<LoopBodyStatement<'a, I, E>>),
+    Return(Expression<'a, I, E>),
     Break,
     Continue,
 }
@@ -984,7 +1015,7 @@ pub enum LoopBodyStatement<'a, E: ExtendedExpression> {
     derive(Serialize, Deserialize),
     serde(tag = "type", content = "content")
 )]
-pub enum MainStatement<'a, E: ExtendedExpression> {
+pub enum MainStatement<'a, I: SemanticContextInstruction, E: ExtendedExpression<I>> {
     /// Import declarations
     #[cfg_attr(feature = "codec", serde(borrow))]
     Import(ImportPath<'a>),
@@ -993,10 +1024,10 @@ pub enum MainStatement<'a, E: ExtendedExpression> {
     /// Type declaration
     Types(StructTypes<'a>),
     /// Function declaration and function body-statement
-    Function(FunctionStatement<'a, E>),
+    Function(FunctionStatement<'a, I, E>),
 }
 
 /// # Main
 /// Stack of `MainStatement` main AST elements. That gather
 /// tries of AST, to represent full sort of source code.
-pub type Main<'a, E> = Vec<MainStatement<'a, E>>;
+pub type Main<'a, I, E> = Vec<MainStatement<'a, I, E>>;

--- a/src/semantic.rs
+++ b/src/semantic.rs
@@ -17,7 +17,7 @@ use crate::types::expression::{
 };
 use crate::types::semantic::{
     ExtendedExpression, GlobalSemanticContext, SemanticContext, SemanticContextInstruction,
-    SemanticStack,
+    SemanticStack, SemanticStackContext,
 };
 use crate::types::types::{Type, TypeName};
 use crate::types::{

--- a/src/types/block_state.rs
+++ b/src/types/block_state.rs
@@ -1,7 +1,7 @@
 //! # Block State types
 //! Block state Semantic types.
 
-use super::semantic::{SemanticContextInstruction, SemanticStack};
+use super::semantic::{SemanticContextInstruction, SemanticStack, SemanticStackContext};
 use super::{Constant, Function, FunctionParameter, InnerValueName, LabelName, Value, ValueName};
 use crate::types::condition::{Condition, LogicCondition};
 use crate::types::expression::{ExpressionOperations, ExpressionResult};
@@ -97,6 +97,10 @@ impl<I: SemanticContextInstruction> BlockState<I> {
     #[must_use]
     pub fn get_context(&self) -> SemanticStack<I> {
         self.context.clone()
+    }
+
+    pub fn set_context(&mut self, data: SemanticStackContext<I>) {
+        self.context.push(data);
     }
 
     /// Set `last_register_number` for current and parent states

--- a/src/types/block_state.rs
+++ b/src/types/block_state.rs
@@ -1,7 +1,7 @@
 //! # Block State types
 //! Block state Semantic types.
 
-use super::semantic::{ExtendedSemanticContext, SemanticContextInstruction, SemanticStack};
+use super::semantic::{SemanticContextInstruction, SemanticStack};
 use super::{Constant, Function, FunctionParameter, InnerValueName, LabelName, Value, ValueName};
 use crate::types::condition::{Condition, LogicCondition};
 use crate::types::expression::{ExpressionOperations, ExpressionResult};
@@ -423,15 +423,6 @@ impl<I: SemanticContextInstruction> SemanticContext for BlockState<I> {
         self.context.function_arg(value.clone(), func_arg.clone());
         if let Some(parent) = &self.parent {
             parent.borrow_mut().function_arg(value, func_arg);
-        }
-    }
-}
-
-impl<I: SemanticContextInstruction> ExtendedSemanticContext<I> for BlockState<I> {
-    fn extended_expression(&mut self, expr: &I) {
-        self.context.extended_expression(expr);
-        if let Some(parent) = &self.parent {
-            parent.borrow_mut().extended_expression(expr);
         }
     }
 }

--- a/src/types/block_state.rs
+++ b/src/types/block_state.rs
@@ -1,7 +1,7 @@
 //! # Block State types
 //! Block state Semantic types.
 
-use super::semantic::{SemanticContextInstruction, SemanticStack, SemanticStackContext};
+use super::semantic::{ExtendedSemanticContext, SemanticContextInstruction, SemanticStack};
 use super::{Constant, Function, FunctionParameter, InnerValueName, LabelName, Value, ValueName};
 use crate::types::condition::{Condition, LogicCondition};
 use crate::types::expression::{ExpressionOperations, ExpressionResult};
@@ -97,10 +97,6 @@ impl<I: SemanticContextInstruction> BlockState<I> {
     #[must_use]
     pub fn get_context(&self) -> SemanticStack<I> {
         self.context.clone()
-    }
-
-    pub fn set_context(&mut self, data: SemanticStackContext<I>) {
-        self.context.push(data);
     }
 
     /// Set `last_register_number` for current and parent states
@@ -427,6 +423,15 @@ impl<I: SemanticContextInstruction> SemanticContext for BlockState<I> {
         self.context.function_arg(value.clone(), func_arg.clone());
         if let Some(parent) = &self.parent {
             parent.borrow_mut().function_arg(value, func_arg);
+        }
+    }
+}
+
+impl<I: SemanticContextInstruction> ExtendedSemanticContext<I> for BlockState<I> {
+    fn extended_expression(&mut self, expr: &I) {
+        self.context.extended_expression(expr);
+        if let Some(parent) = &self.parent {
+            parent.borrow_mut().extended_expression(expr);
         }
     }
 }

--- a/src/types/condition.rs
+++ b/src/types/condition.rs
@@ -4,7 +4,7 @@
 use super::expression::Expression;
 use super::{Binding, FunctionCall, LetBinding};
 use crate::ast;
-use crate::types::semantic::ExtendedExpression;
+use crate::types::semantic::{ExtendedExpression, SemanticContextInstruction};
 #[cfg(feature = "codec")]
 use serde::{Deserialize, Serialize};
 
@@ -71,8 +71,10 @@ pub struct ExpressionCondition {
     pub right: Expression,
 }
 
-impl<E: ExtendedExpression> From<ast::ExpressionCondition<'_, E>> for ExpressionCondition {
-    fn from(value: ast::ExpressionCondition<'_, E>) -> Self {
+impl<I: SemanticContextInstruction, E: ExtendedExpression<I>>
+    From<ast::ExpressionCondition<'_, I, E>> for ExpressionCondition
+{
+    fn from(value: ast::ExpressionCondition<'_, I, E>) -> Self {
         Self {
             left: value.left.into(),
             condition: value.condition.into(),
@@ -93,10 +95,10 @@ pub struct ExpressionLogicCondition {
     pub right: Option<(LogicCondition, Box<ExpressionLogicCondition>)>,
 }
 
-impl<E: ExtendedExpression> From<ast::ExpressionLogicCondition<'_, E>>
-    for ExpressionLogicCondition
+impl<I: SemanticContextInstruction, E: ExtendedExpression<I>>
+    From<ast::ExpressionLogicCondition<'_, I, E>> for ExpressionLogicCondition
 {
-    fn from(value: ast::ExpressionLogicCondition<'_, E>) -> Self {
+    fn from(value: ast::ExpressionLogicCondition<'_, I, E>) -> Self {
         Self {
             left: value.left.into(),
             right: value
@@ -120,8 +122,10 @@ pub enum IfCondition {
     Logic(ExpressionLogicCondition),
 }
 
-impl<E: ExtendedExpression> From<ast::IfCondition<'_, E>> for IfCondition {
-    fn from(value: ast::IfCondition<'_, E>) -> Self {
+impl<I: SemanticContextInstruction, E: ExtendedExpression<I>> From<ast::IfCondition<'_, I, E>>
+    for IfCondition
+{
+    fn from(value: ast::IfCondition<'_, I, E>) -> Self {
         match value {
             ast::IfCondition::Single(v) => Self::Single(v.into()),
             ast::IfCondition::Logic(v) => Self::Logic(v.into()),
@@ -144,8 +148,10 @@ pub struct IfStatement {
     pub else_if_statement: Option<Box<IfStatement>>,
 }
 
-impl<E: ExtendedExpression> From<ast::IfStatement<'_, E>> for IfStatement {
-    fn from(value: ast::IfStatement<'_, E>) -> Self {
+impl<I: SemanticContextInstruction, E: ExtendedExpression<I>> From<ast::IfStatement<'_, I, E>>
+    for IfStatement
+{
+    fn from(value: ast::IfStatement<'_, I, E>) -> Self {
         Self {
             condition: value.condition.into(),
             body: value.body.into(),
@@ -171,8 +177,10 @@ pub enum IfBodyStatements {
     Loop(Vec<IfLoopBodyStatement>),
 }
 
-impl<E: ExtendedExpression> From<ast::IfBodyStatements<'_, E>> for IfBodyStatements {
-    fn from(value: ast::IfBodyStatements<'_, E>) -> Self {
+impl<I: SemanticContextInstruction, E: ExtendedExpression<I>> From<ast::IfBodyStatements<'_, I, E>>
+    for IfBodyStatements
+{
+    fn from(value: ast::IfBodyStatements<'_, I, E>) -> Self {
         match value {
             ast::IfBodyStatements::If(v) => Self::If(v.iter().map(|v| v.clone().into()).collect()),
             ast::IfBodyStatements::Loop(v) => {
@@ -200,8 +208,10 @@ pub enum LoopBodyStatement {
     Continue,
 }
 
-impl<E: ExtendedExpression> From<ast::LoopBodyStatement<'_, E>> for LoopBodyStatement {
-    fn from(value: ast::LoopBodyStatement<'_, E>) -> Self {
+impl<I: SemanticContextInstruction, E: ExtendedExpression<I>> From<ast::LoopBodyStatement<'_, I, E>>
+    for LoopBodyStatement
+{
+    fn from(value: ast::LoopBodyStatement<'_, I, E>) -> Self {
         match value {
             ast::LoopBodyStatement::LetBinding(v) => Self::LetBinding(v.into()),
             ast::LoopBodyStatement::Binding(v) => Self::Binding(v.into()),
@@ -233,8 +243,10 @@ pub enum IfBodyStatement {
     Return(Expression),
 }
 
-impl<E: ExtendedExpression> From<ast::IfBodyStatement<'_, E>> for IfBodyStatement {
-    fn from(value: ast::IfBodyStatement<'_, E>) -> Self {
+impl<I: SemanticContextInstruction, E: ExtendedExpression<I>> From<ast::IfBodyStatement<'_, I, E>>
+    for IfBodyStatement
+{
+    fn from(value: ast::IfBodyStatement<'_, I, E>) -> Self {
         match value {
             ast::IfBodyStatement::LetBinding(v) => Self::LetBinding(v.into()),
             ast::IfBodyStatement::Binding(v) => Self::Binding(v.into()),
@@ -267,8 +279,10 @@ pub enum IfLoopBodyStatement {
     Continue,
 }
 
-impl<E: ExtendedExpression> From<ast::IfLoopBodyStatement<'_, E>> for IfLoopBodyStatement {
-    fn from(value: ast::IfLoopBodyStatement<'_, E>) -> Self {
+impl<I: SemanticContextInstruction, E: ExtendedExpression<I>>
+    From<ast::IfLoopBodyStatement<'_, I, E>> for IfLoopBodyStatement
+{
+    fn from(value: ast::IfLoopBodyStatement<'_, I, E>) -> Self {
         match value {
             ast::IfLoopBodyStatement::LetBinding(v) => Self::LetBinding(v.into()),
             ast::IfLoopBodyStatement::Binding(v) => Self::Binding(v.into()),

--- a/src/types/expression.rs
+++ b/src/types/expression.rs
@@ -4,7 +4,7 @@
 use super::types::Type;
 use super::{FunctionCall, PrimitiveValue, ValueName};
 use crate::ast;
-use crate::types::semantic::ExtendedExpression;
+use crate::types::semantic::{ExtendedExpression, SemanticContextInstruction};
 #[cfg(feature = "codec")]
 use serde::{Deserialize, Serialize};
 
@@ -78,9 +78,12 @@ impl ToString for ExpressionValue {
     }
 }
 
-impl<E: ExtendedExpression> From<ast::ExpressionValue<'_, E>> for ExpressionValue {
-    fn from(value: ast::ExpressionValue<'_, E>) -> Self {
+impl<I: SemanticContextInstruction, E: ExtendedExpression<I>> From<ast::ExpressionValue<'_, I, E>>
+    for ExpressionValue
+{
+    fn from(value: ast::ExpressionValue<'_, I, E>) -> Self {
         match value {
+            ast::ExpressionValue::_Marker(..) => unreachable!(),
             ast::ExpressionValue::ValueName(v) => Self::ValueName(v.into()),
             ast::ExpressionValue::PrimitiveValue(v) => Self::PrimitiveValue(v.into()),
             ast::ExpressionValue::StructValue(v) => Self::StructValue(v.into()),
@@ -188,8 +191,10 @@ impl ToString for Expression {
     }
 }
 
-impl<E: ExtendedExpression> From<ast::Expression<'_, E>> for Expression {
-    fn from(value: ast::Expression<'_, E>) -> Self {
+impl<I: SemanticContextInstruction, E: ExtendedExpression<I>> From<ast::Expression<'_, I, E>>
+    for Expression
+{
+    fn from(value: ast::Expression<'_, I, E>) -> Self {
         Self {
             expression_value: value.expression_value.into(),
             operation: value

--- a/src/types/expression.rs
+++ b/src/types/expression.rs
@@ -7,6 +7,7 @@ use crate::ast;
 use crate::types::semantic::{ExtendedExpression, SemanticContextInstruction};
 #[cfg(feature = "codec")]
 use serde::{Deserialize, Serialize};
+use std::fmt::Display;
 
 /// # Expression result
 /// Contains analyzing results of expression:
@@ -65,16 +66,17 @@ pub enum ExpressionValue {
     ExtendedExpression(ExtendedExpressionValue),
 }
 
-impl ToString for ExpressionValue {
-    fn to_string(&self) -> String {
-        match self {
+impl Display for ExpressionValue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let str = match self {
             Self::ValueName(val) => val.clone().to_string(),
             Self::PrimitiveValue(val) => val.clone().to_string(),
             Self::StructValue(st_val) => st_val.clone().to_string(),
             Self::FunctionCall(fn_call) => fn_call.clone().to_string(),
             Self::Expression(val) => val.to_string(),
             Self::ExtendedExpression(val) => val.clone().0,
-        }
+        };
+        write!(f, "{str}")
     }
 }
 
@@ -109,9 +111,9 @@ pub struct ExpressionStructValue {
     pub attribute: ValueName,
 }
 
-impl ToString for ExpressionStructValue {
-    fn to_string(&self) -> String {
-        self.name.to_string()
+impl Display for ExpressionStructValue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.name)
     }
 }
 
@@ -185,9 +187,9 @@ pub struct Expression {
     pub operation: Option<(ExpressionOperations, Box<Expression>)>,
 }
 
-impl ToString for Expression {
-    fn to_string(&self) -> String {
-        self.expression_value.to_string()
+impl Display for Expression {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.expression_value)
     }
 }
 

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -29,6 +29,7 @@ use crate::ast::GetName;
 use crate::types::semantic::{ExtendedExpression, SemanticContextInstruction};
 #[cfg(feature = "codec")]
 use serde::{Deserialize, Serialize};
+use std::fmt::Display;
 
 /// Value name type
 #[derive(Debug, Clone, Eq, Hash, PartialEq)]
@@ -53,9 +54,9 @@ impl From<&str> for ValueName {
     }
 }
 
-impl ToString for ValueName {
-    fn to_string(&self) -> String {
-        self.0.clone()
+impl Display for ValueName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0.clone())
     }
 }
 
@@ -82,9 +83,9 @@ impl From<&str> for InnerValueName {
     }
 }
 
-impl ToString for InnerValueName {
-    fn to_string(&self) -> String {
-        self.0.clone()
+impl Display for InnerValueName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0.clone())
     }
 }
 
@@ -99,9 +100,9 @@ impl From<String> for LabelName {
     }
 }
 
-impl ToString for LabelName {
-    fn to_string(&self) -> String {
-        self.0.clone()
+impl Display for LabelName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0.clone())
     }
 }
 
@@ -122,9 +123,9 @@ impl From<ast::FunctionName<'_>> for FunctionName {
     }
 }
 
-impl ToString for FunctionName {
-    fn to_string(&self) -> String {
-        self.0.clone()
+impl Display for FunctionName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0.clone())
     }
 }
 
@@ -145,9 +146,9 @@ impl From<String> for ConstantName {
     }
 }
 
-impl ToString for ConstantName {
-    fn to_string(&self) -> String {
-        self.0.clone()
+impl Display for ConstantName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0.clone())
     }
 }
 
@@ -252,7 +253,7 @@ pub struct Function {
     pub inner_name: FunctionName,
     /// Inner (return) type
     pub inner_type: Type,
-    /// Function parameters typesz
+    /// Function parameters types
     pub parameters: Vec<Type>,
 }
 
@@ -286,9 +287,9 @@ impl From<ast::FunctionParameter<'_>> for FunctionParameter {
     }
 }
 
-impl ToString for FunctionParameter {
-    fn to_string(&self) -> String {
-        self.name.0.clone()
+impl Display for FunctionParameter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.name.0.clone())
     }
 }
 
@@ -375,9 +376,9 @@ pub struct LetBinding {
     pub value: Box<Expression>,
 }
 
-impl ToString for LetBinding {
-    fn to_string(&self) -> String {
-        self.name.to_string()
+impl Display for LetBinding {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.name)
     }
 }
 
@@ -442,9 +443,9 @@ impl From<ast::PrimitiveValue> for PrimitiveValue {
     }
 }
 
-impl ToString for PrimitiveValue {
-    fn to_string(&self) -> String {
-        match self {
+impl Display for PrimitiveValue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let str = match self {
             Self::U8(val) => val.clone().to_string(),
             Self::U16(val) => val.clone().to_string(),
             Self::U32(val) => val.clone().to_string(),
@@ -460,7 +461,8 @@ impl ToString for PrimitiveValue {
             Self::Char(c) => format!("{c}"),
             Self::Ptr => "ptr".to_string(),
             Self::None => "None".to_string(),
-        }
+        };
+        write!(f, "{str}")
     }
 }
 
@@ -475,9 +477,9 @@ pub struct FunctionCall {
     pub parameters: Vec<Expression>,
 }
 
-impl ToString for FunctionCall {
-    fn to_string(&self) -> String {
-        self.name.to_string()
+impl Display for FunctionCall {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.name)
     }
 }
 
@@ -502,9 +504,9 @@ pub struct Binding {
     pub value: Box<Expression>,
 }
 
-impl ToString for Binding {
-    fn to_string(&self) -> String {
-        self.name.to_string()
+impl Display for Binding {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.name)
     }
 }
 

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -7,6 +7,7 @@
 //! - Error types
 
 #![allow(clippy::module_inception)]
+
 /// Block state types
 pub mod block_state;
 /// Condition types
@@ -25,7 +26,7 @@ use self::expression::{Expression, ExpressionOperations};
 use self::types::Type;
 use crate::ast;
 use crate::ast::GetName;
-use crate::types::semantic::ExtendedExpression;
+use crate::types::semantic::{ExtendedExpression, SemanticContextInstruction};
 #[cfg(feature = "codec")]
 use serde::{Deserialize, Serialize};
 
@@ -114,6 +115,7 @@ impl From<String> for FunctionName {
         Self(value)
     }
 }
+
 impl From<ast::FunctionName<'_>> for FunctionName {
     fn from(value: ast::FunctionName<'_>) -> Self {
         Self(value.to_string())
@@ -310,8 +312,10 @@ pub struct FunctionStatement {
     pub body: Vec<BodyStatement>,
 }
 
-impl<E: ExtendedExpression> From<ast::FunctionStatement<'_, E>> for FunctionStatement {
-    fn from(value: ast::FunctionStatement<'_, E>) -> Self {
+impl<I: SemanticContextInstruction, E: ExtendedExpression<I>> From<ast::FunctionStatement<'_, I, E>>
+    for FunctionStatement
+{
+    fn from(value: ast::FunctionStatement<'_, I, E>) -> Self {
         Self {
             name: value.name.into(),
             parameters: value.parameters.iter().map(|v| v.clone().into()).collect(),
@@ -340,8 +344,10 @@ pub enum BodyStatement {
     Return(Expression),
 }
 
-impl<E: ExtendedExpression> From<ast::BodyStatement<'_, E>> for BodyStatement {
-    fn from(value: ast::BodyStatement<'_, E>) -> Self {
+impl<I: SemanticContextInstruction, E: ExtendedExpression<I>> From<ast::BodyStatement<'_, I, E>>
+    for BodyStatement
+{
+    fn from(value: ast::BodyStatement<'_, I, E>) -> Self {
         match value {
             ast::BodyStatement::LetBinding(v) => Self::LetBinding(v.into()),
             ast::BodyStatement::Binding(v) => Self::Binding(v.into()),
@@ -375,8 +381,10 @@ impl ToString for LetBinding {
     }
 }
 
-impl<E: ExtendedExpression> From<ast::LetBinding<'_, E>> for LetBinding {
-    fn from(value: ast::LetBinding<'_, E>) -> Self {
+impl<I: SemanticContextInstruction, E: ExtendedExpression<I>> From<ast::LetBinding<'_, I, E>>
+    for LetBinding
+{
+    fn from(value: ast::LetBinding<'_, I, E>) -> Self {
         Self {
             name: value.name.into(),
             mutable: value.mutable,
@@ -473,8 +481,10 @@ impl ToString for FunctionCall {
     }
 }
 
-impl<E: ExtendedExpression> From<ast::FunctionCall<'_, E>> for FunctionCall {
-    fn from(value: ast::FunctionCall<'_, E>) -> Self {
+impl<I: SemanticContextInstruction, E: ExtendedExpression<I>> From<ast::FunctionCall<'_, I, E>>
+    for FunctionCall
+{
+    fn from(value: ast::FunctionCall<'_, I, E>) -> Self {
         Self {
             name: value.name.into(),
             parameters: value.parameters.iter().map(|v| v.clone().into()).collect(),
@@ -498,8 +508,10 @@ impl ToString for Binding {
     }
 }
 
-impl<E: ExtendedExpression> From<ast::Binding<'_, E>> for Binding {
-    fn from(value: ast::Binding<'_, E>) -> Self {
+impl<I: SemanticContextInstruction, E: ExtendedExpression<I>> From<ast::Binding<'_, I, E>>
+    for Binding
+{
+    fn from(value: ast::Binding<'_, I, E>) -> Self {
         Self {
             name: value.name.into(),
             value: Box::new(value.value.as_ref().clone().into()),

--- a/src/types/semantic.rs
+++ b/src/types/semantic.rs
@@ -75,12 +75,6 @@ pub trait SemanticContext {
     fn function_arg(&mut self, value: Value, func_arg: FunctionParameter);
 }
 
-/// Extended Semantic Context trait contain instructions set functions
-/// for the Extended Stack context.
-pub trait ExtendedSemanticContext<I: SemanticContextInstruction> {
-    fn extended_expression(&mut self, expr: &I);
-}
-
 /// Semantic Context trait contains custom instruction implementation
 /// to flexibly extend context instructions.
 pub trait SemanticContextInstruction: Clone {
@@ -412,15 +406,6 @@ impl<I: SemanticContextInstruction> SemanticContext for SemanticStack<I> {
     /// - `func_arg` - function parameter data
     fn function_arg(&mut self, value: Value, func_arg: FunctionParameter) {
         self.push(SemanticStackContext::FunctionArg { value, func_arg });
-    }
-}
-
-impl<I: SemanticContextInstruction> ExtendedSemanticContext<I> for SemanticStack<I> {
-    /// Extended Expression instruction.
-    /// AS argument trait, that contains instruction method that returns
-    /// instruction parameters.
-    fn extended_expression(&mut self, expr: &I) {
-        self.push(SemanticStackContext::ExtendedExpression(expr.instruction()));
     }
 }
 

--- a/src/types/semantic.rs
+++ b/src/types/semantic.rs
@@ -82,12 +82,9 @@ pub trait ExtendedSemanticContext<I: SemanticContextInstruction> {
 }
 
 /// Semantic Context trait contains custom instruction implementation
-/// to flexibly extend context instructions.
-pub trait SemanticContextInstruction: Debug + Clone + PartialEq {
-    /// Custom instruction implementation.
-    /// Ast should be received from `GetAst` trait.
-    fn instruction(&self) -> Box<Self>;
-}
+/// to flexibly extend context instructions. It represents ivs derided
+/// traits: `Debug` and `Serialize` + `Deserialize`
+pub trait SemanticContextInstruction: Debug + Clone + PartialEq {}
 
 /// Extended Expression for semantic analyzer.
 pub trait ExtendedExpression<I: SemanticContextInstruction>: Debug + Clone + PartialEq {
@@ -426,7 +423,9 @@ impl<I: SemanticContextInstruction> ExtendedSemanticContext<I> for SemanticStack
     /// AS argument trait, that contains instruction method that returns
     /// instruction parameters.
     fn extended_expression(&mut self, expr: &I) {
-        self.push(SemanticStackContext::ExtendedExpression(expr.instruction()));
+        self.push(SemanticStackContext::ExtendedExpression(Box::new(
+            expr.clone(),
+        )));
     }
 }
 

--- a/src/types/semantic.rs
+++ b/src/types/semantic.rs
@@ -77,11 +77,7 @@ pub trait SemanticContext {
 
 /// Semantic Context trait contains custom instruction implementation
 /// to flexibly extend context instructions.
-pub trait SemanticContextInstruction: Clone {
-    /// Custom instruction implementation.
-    /// Ast should be received from `GetAst` trait.
-    fn instruction(&self) -> Box<Self>;
-}
+pub trait SemanticContextInstruction: Debug + Clone {}
 
 /// Extended Expression for semantic analyzer.
 pub trait ExtendedExpression: Debug + Clone + PartialEq {
@@ -502,4 +498,5 @@ pub enum SemanticStackContext<I: SemanticContextInstruction> {
         func_arg: FunctionParameter,
     },
     ExtendedExpression(Box<I>),
+    Test(Box<dyn SemanticContextInstruction>),
 }

--- a/src/types/semantic.rs
+++ b/src/types/semantic.rs
@@ -105,6 +105,12 @@ pub trait ExtendedExpression<I: SemanticContextInstruction>: Debug + Clone + Par
 #[cfg_attr(feature = "codec", derive(Serialize, Deserialize))]
 pub struct SemanticStack<I: SemanticContextInstruction>(Vec<SemanticStackContext<I>>);
 
+impl<I: SemanticContextInstruction> Default for SemanticStack<I> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<I: SemanticContextInstruction> SemanticStack<I> {
     /// Init Semantic stack
     #[must_use]

--- a/src/types/types.rs
+++ b/src/types/types.rs
@@ -6,6 +6,7 @@ use crate::ast::{self, GetName};
 #[cfg(feature = "codec")]
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::fmt::Display;
 
 /// `TypeAttributes` type attributes trait.
 /// Used for types declarations.
@@ -39,9 +40,9 @@ impl From<String> for TypeName {
     }
 }
 
-impl ToString for TypeName {
-    fn to_string(&self) -> String {
-        self.0.clone()
+impl Display for TypeName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0.clone())
     }
 }
 
@@ -79,15 +80,16 @@ impl Type {
     }
 }
 
-impl ToString for Type {
-    fn to_string(&self) -> String {
-        match self {
+impl Display for Type {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let str = match self {
             Self::Primitive(primitive) => primitive.to_string(),
             Self::Struct(struct_type) => struct_type.name.clone(),
             Self::Array(array_type, size) => {
                 format!("[{:?};{:?}]", array_type.to_string(), size)
             }
-        }
+        };
+        write!(f, "{str}",)
     }
 }
 
@@ -160,8 +162,8 @@ pub enum PrimitiveTypes {
     None,
 }
 
-impl ToString for PrimitiveTypes {
-    fn to_string(&self) -> String {
+impl Display for PrimitiveTypes {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let s = match self {
             Self::U8 => "u8",
             Self::U16 => "u16",
@@ -179,7 +181,7 @@ impl ToString for PrimitiveTypes {
             Self::Ptr => "ptr",
             Self::None => "()",
         };
-        s.to_string()
+        write!(f, "{s}")
     }
 }
 

--- a/tests/binding_tests.rs
+++ b/tests/binding_tests.rs
@@ -1,4 +1,4 @@
-use crate::utils::{CustomExpression, SemanticTest};
+use crate::utils::{CustomExpression, CustomExpressionInstruction, SemanticTest};
 use semantic_analyzer::ast;
 use semantic_analyzer::ast::{CodeLocation, GetLocation, GetName, Ident, ValueName};
 use semantic_analyzer::types::block_state::BlockState;
@@ -15,9 +15,10 @@ mod utils;
 #[test]
 fn binding_transform() {
     let expr_ast = ast::Expression {
-        expression_value: ast::ExpressionValue::<CustomExpression>::PrimitiveValue(
-            ast::PrimitiveValue::U64(3),
-        ),
+        expression_value: ast::ExpressionValue::<
+            CustomExpressionInstruction,
+            CustomExpression<CustomExpressionInstruction>,
+        >::PrimitiveValue(ast::PrimitiveValue::U64(3)),
         operation: None,
     };
     let binding_ast = ast::Binding {
@@ -39,9 +40,10 @@ fn binding_wrong_expression() {
     let block_state = Rc::new(RefCell::new(BlockState::new(None)));
     let mut t = SemanticTest::new();
     let expr = ast::Expression {
-        expression_value: ast::ExpressionValue::<CustomExpression>::ValueName(ast::ValueName::new(
-            Ident::new("x"),
-        )),
+        expression_value: ast::ExpressionValue::<
+            CustomExpressionInstruction,
+            CustomExpression<CustomExpressionInstruction>,
+        >::ValueName(ast::ValueName::new(Ident::new("x"))),
         operation: None,
     };
     let binding = ast::Binding {
@@ -62,9 +64,10 @@ fn binding_value_not_exist() {
     let block_state = Rc::new(RefCell::new(BlockState::new(None)));
     let mut t = SemanticTest::new();
     let expr = ast::Expression {
-        expression_value: ast::ExpressionValue::<CustomExpression>::PrimitiveValue(
-            ast::PrimitiveValue::I16(23),
-        ),
+        expression_value: ast::ExpressionValue::<
+            CustomExpressionInstruction,
+            CustomExpression<CustomExpressionInstruction>,
+        >::PrimitiveValue(ast::PrimitiveValue::I16(23)),
         operation: None,
     };
     let binding = ast::Binding {
@@ -85,9 +88,10 @@ fn binding_value_not_mutable() {
     let block_state = Rc::new(RefCell::new(BlockState::new(None)));
     let mut t = SemanticTest::new();
     let expr = ast::Expression {
-        expression_value: ast::ExpressionValue::<CustomExpression>::PrimitiveValue(
-            ast::PrimitiveValue::U64(30),
-        ),
+        expression_value: ast::ExpressionValue::<
+            CustomExpressionInstruction,
+            CustomExpression<CustomExpressionInstruction>,
+        >::PrimitiveValue(ast::PrimitiveValue::U64(30)),
         operation: None,
     };
     let let_binding = ast::LetBinding {
@@ -115,7 +119,7 @@ fn binding_value_not_mutable() {
             let_decl: val.clone(),
             expr_result: ExpressionResult {
                 expr_type: Type::Primitive(PrimitiveTypes::U64),
-                expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::U64(30))
+                expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::U64(30)),
             },
         }
     );
@@ -142,9 +146,10 @@ fn binding_value_found() {
     let block_state = Rc::new(RefCell::new(BlockState::new(None)));
     let mut t = SemanticTest::new();
     let expr = ast::Expression {
-        expression_value: ast::ExpressionValue::<CustomExpression>::PrimitiveValue(
-            ast::PrimitiveValue::U64(30),
-        ),
+        expression_value: ast::ExpressionValue::<
+            CustomExpressionInstruction,
+            CustomExpression<CustomExpressionInstruction>,
+        >::PrimitiveValue(ast::PrimitiveValue::U64(30)),
         operation: None,
     };
     let let_binding = ast::LetBinding {
@@ -172,7 +177,7 @@ fn binding_value_found() {
             let_decl: val.clone(),
             expr_result: ExpressionResult {
                 expr_type: Type::Primitive(PrimitiveTypes::U64),
-                expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::U64(30))
+                expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::U64(30)),
             },
         }
     );
@@ -182,9 +187,10 @@ fn binding_value_found() {
         &val
     );
     let new_expr = ast::Expression {
-        expression_value: ast::ExpressionValue::<CustomExpression>::PrimitiveValue(
-            ast::PrimitiveValue::U64(100),
-        ),
+        expression_value: ast::ExpressionValue::<
+            CustomExpressionInstruction,
+            CustomExpression<CustomExpressionInstruction>,
+        >::PrimitiveValue(ast::PrimitiveValue::U64(100)),
         operation: None,
     };
     let binding = ast::Binding {
@@ -201,7 +207,7 @@ fn binding_value_found() {
             let_decl: val.clone(),
             expr_result: ExpressionResult {
                 expr_type: Type::Primitive(PrimitiveTypes::U64),
-                expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::U64(30))
+                expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::U64(30)),
             },
         }
     );
@@ -211,7 +217,7 @@ fn binding_value_found() {
             val: val.clone(),
             expr_result: ExpressionResult {
                 expr_type: Type::Primitive(PrimitiveTypes::U64),
-                expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::U64(100))
+                expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::U64(100)),
             },
         }
     );

--- a/tests/expressions_tests.rs
+++ b/tests/expressions_tests.rs
@@ -1332,17 +1332,13 @@ fn custom_expression() {
     }
 
     #[derive(Clone, Debug, PartialEq)]
-    #[allow(dead_code)]
+    #[cfg_attr(feature = "codec", derive(serde::Serialize, serde::Deserialize))]
     pub enum CustomExpressionInstruction {
         GoIn { index: u32, value: u32 },
         GoOut { result: u32 },
     }
 
-    impl SemanticContextInstruction for CustomExpressionInstruction {
-        fn instruction(&self) -> Box<Self> {
-            Box::new(self.clone())
-        }
-    }
+    impl SemanticContextInstruction for CustomExpressionInstruction {}
 
     impl ExtendedExpression<CustomExpressionInstruction>
         for CustomExpression<CustomExpressionInstruction>
@@ -1438,4 +1434,12 @@ fn custom_expression() {
             register_number: 3,
         }
     );
+
+    #[cfg(feature = "codec")]
+    {
+        let json = serde_json::to_string(&bs).unwrap();
+        let bs_decoded: Vec<SemanticStackContext<CustomExpressionInstruction>> =
+            serde_json::from_str(&json).unwrap();
+        assert_eq!(bs, bs_decoded);
+    }
 }

--- a/tests/expressions_tests.rs
+++ b/tests/expressions_tests.rs
@@ -1,15 +1,12 @@
-use crate::utils::{CustomExpression, SemanticTest};
+use crate::utils::{CustomExpression, CustomExpressionInstruction, SemanticTest};
 use semantic_analyzer::ast;
 use semantic_analyzer::ast::{
     CodeLocation, GetLocation, GetName, Ident, MAX_PRIORITY_LEVEL_FOR_EXPRESSIONS,
 };
-use semantic_analyzer::semantic::State;
 use semantic_analyzer::types::expression::{
     Expression, ExpressionOperations, ExpressionResult, ExpressionStructValue, ExpressionValue,
 };
-use semantic_analyzer::types::semantic::{
-    ExtendedExpression, SemanticContextInstruction, SemanticStackContext,
-};
+use semantic_analyzer::types::semantic::{ExtendedSemanticContext, SemanticStackContext};
 use semantic_analyzer::types::{
     block_state::BlockState,
     error::StateErrorKind,
@@ -19,7 +16,7 @@ use semantic_analyzer::types::{
     ValueName,
 };
 use std::cell::RefCell;
-use std::fmt::Debug;
+use std::marker::PhantomData;
 use std::rc::Rc;
 
 mod utils;
@@ -31,7 +28,7 @@ fn set_result_type(
     reg_right: bool,
     right: u64,
     register_number: u64,
-) -> SemanticStackContext<CustomExpression> {
+) -> SemanticStackContext<CustomExpressionInstruction> {
     let left_val = if reg_left {
         ExpressionResultValue::Register(left)
     } else {
@@ -60,7 +57,10 @@ fn set_result_type(
 fn expression_ast_transform() {
     let value_name = ast::ValueName::new(Ident::new("x"));
     let expr = ast::Expression {
-        expression_value: ast::ExpressionValue::<CustomExpression>::ValueName(value_name.clone()),
+        expression_value: ast::ExpressionValue::<
+            CustomExpressionInstruction,
+            CustomExpression<CustomExpressionInstruction>,
+        >::ValueName(value_name.clone()),
         operation: None,
     };
     assert_eq!(expr.location(), CodeLocation::new(1, 0));
@@ -90,7 +90,10 @@ fn expression_ast_transform_primitive_value_i8() {
     assert_eq!(PrimitiveValue::I8(3), expr_val);
     assert_eq!(expr_val.to_string(), "3");
     let expr: Expression = ast::Expression {
-        expression_value: ast::ExpressionValue::<CustomExpression>::PrimitiveValue(val),
+        expression_value: ast::ExpressionValue::<
+            CustomExpressionInstruction,
+            CustomExpression<CustomExpressionInstruction>,
+        >::PrimitiveValue(val),
         operation: None,
     }
     .into();
@@ -108,7 +111,10 @@ fn expression_ast_transform_primitive_value_i16() {
     assert_eq!(PrimitiveValue::I16(3), expr_val);
     assert_eq!(expr_val.to_string(), "3");
     let expr: Expression = ast::Expression {
-        expression_value: ast::ExpressionValue::<CustomExpression>::PrimitiveValue(val),
+        expression_value: ast::ExpressionValue::<
+            CustomExpressionInstruction,
+            CustomExpression<CustomExpressionInstruction>,
+        >::PrimitiveValue(val),
         operation: None,
     }
     .into();
@@ -126,7 +132,10 @@ fn expression_ast_transform_primitive_value_i32() {
     assert_eq!(PrimitiveValue::I32(3), expr_val);
     assert_eq!(expr_val.to_string(), "3");
     let expr: Expression = ast::Expression {
-        expression_value: ast::ExpressionValue::<CustomExpression>::PrimitiveValue(val),
+        expression_value: ast::ExpressionValue::<
+            CustomExpressionInstruction,
+            CustomExpression<CustomExpressionInstruction>,
+        >::PrimitiveValue(val),
         operation: None,
     }
     .into();
@@ -144,7 +153,10 @@ fn expression_ast_transform_primitive_value_i64() {
     assert_eq!(PrimitiveValue::I64(3), expr_val);
     assert_eq!(expr_val.to_string(), "3");
     let expr: Expression = ast::Expression {
-        expression_value: ast::ExpressionValue::<CustomExpression>::PrimitiveValue(val),
+        expression_value: ast::ExpressionValue::<
+            CustomExpressionInstruction,
+            CustomExpression<CustomExpressionInstruction>,
+        >::PrimitiveValue(val),
         operation: None,
     }
     .into();
@@ -162,7 +174,10 @@ fn expression_ast_transform_primitive_value_u8() {
     assert_eq!(PrimitiveValue::U8(3), expr_val);
     assert_eq!(expr_val.to_string(), "3");
     let expr: Expression = ast::Expression {
-        expression_value: ast::ExpressionValue::<CustomExpression>::PrimitiveValue(val),
+        expression_value: ast::ExpressionValue::<
+            CustomExpressionInstruction,
+            CustomExpression<CustomExpressionInstruction>,
+        >::PrimitiveValue(val),
         operation: None,
     }
     .into();
@@ -180,7 +195,10 @@ fn expression_ast_transform_primitive_value_u16() {
     assert_eq!(PrimitiveValue::U16(3), expr_val);
     assert_eq!(expr_val.to_string(), "3");
     let expr: Expression = ast::Expression {
-        expression_value: ast::ExpressionValue::<CustomExpression>::PrimitiveValue(val),
+        expression_value: ast::ExpressionValue::<
+            CustomExpressionInstruction,
+            CustomExpression<CustomExpressionInstruction>,
+        >::PrimitiveValue(val),
         operation: None,
     }
     .into();
@@ -198,7 +216,10 @@ fn expression_ast_transform_primitive_value_u32() {
     assert_eq!(PrimitiveValue::U32(3), expr_val);
     assert_eq!(expr_val.to_string(), "3");
     let expr: Expression = ast::Expression {
-        expression_value: ast::ExpressionValue::<CustomExpression>::PrimitiveValue(val),
+        expression_value: ast::ExpressionValue::<
+            CustomExpressionInstruction,
+            CustomExpression<CustomExpressionInstruction>,
+        >::PrimitiveValue(val),
         operation: None,
     }
     .into();
@@ -216,7 +237,10 @@ fn expression_ast_transform_primitive_value_u64() {
     assert_eq!(PrimitiveValue::U64(3), expr_val);
     assert_eq!(expr_val.to_string(), "3");
     let expr: Expression = ast::Expression {
-        expression_value: ast::ExpressionValue::<CustomExpression>::PrimitiveValue(val),
+        expression_value: ast::ExpressionValue::<
+            CustomExpressionInstruction,
+            CustomExpression<CustomExpressionInstruction>,
+        >::PrimitiveValue(val),
         operation: None,
     }
     .into();
@@ -234,7 +258,10 @@ fn expression_ast_transform_primitive_value_f32() {
     assert_eq!(PrimitiveValue::F32(3.1), expr_val);
     assert_eq!(expr_val.to_string(), "3.1");
     let expr: Expression = ast::Expression {
-        expression_value: ast::ExpressionValue::<CustomExpression>::PrimitiveValue(val),
+        expression_value: ast::ExpressionValue::<
+            CustomExpressionInstruction,
+            CustomExpression<CustomExpressionInstruction>,
+        >::PrimitiveValue(val),
         operation: None,
     }
     .into();
@@ -252,7 +279,10 @@ fn expression_ast_transform_primitive_value_f64() {
     assert_eq!(PrimitiveValue::F64(3.1), expr_val);
     assert_eq!(expr_val.to_string(), "3.1");
     let expr: Expression = ast::Expression {
-        expression_value: ast::ExpressionValue::<CustomExpression>::PrimitiveValue(val),
+        expression_value: ast::ExpressionValue::<
+            CustomExpressionInstruction,
+            CustomExpression<CustomExpressionInstruction>,
+        >::PrimitiveValue(val),
         operation: None,
     }
     .into();
@@ -270,7 +300,10 @@ fn expression_ast_transform_primitive_value_bool() {
     assert_eq!(PrimitiveValue::Bool(true), expr_val);
     assert_eq!(expr_val.to_string(), "true");
     let expr: Expression = ast::Expression {
-        expression_value: ast::ExpressionValue::<CustomExpression>::PrimitiveValue(val),
+        expression_value: ast::ExpressionValue::<
+            CustomExpressionInstruction,
+            CustomExpression<CustomExpressionInstruction>,
+        >::PrimitiveValue(val),
         operation: None,
     }
     .into();
@@ -288,7 +321,10 @@ fn expression_ast_transform_primitive_value_string() {
     assert_eq!(PrimitiveValue::String("str".to_string()), expr_val);
     assert_eq!(expr_val.to_string(), "str");
     let expr: Expression = ast::Expression {
-        expression_value: ast::ExpressionValue::<CustomExpression>::PrimitiveValue(val),
+        expression_value: ast::ExpressionValue::<
+            CustomExpressionInstruction,
+            CustomExpression<CustomExpressionInstruction>,
+        >::PrimitiveValue(val),
         operation: None,
     }
     .into();
@@ -306,7 +342,10 @@ fn expression_ast_transform_primitive_value_char() {
     assert_eq!(PrimitiveValue::Char('a'), expr_val);
     assert_eq!(expr_val.to_string(), "a");
     let expr: Expression = ast::Expression {
-        expression_value: ast::ExpressionValue::<CustomExpression>::PrimitiveValue(val),
+        expression_value: ast::ExpressionValue::<
+            CustomExpressionInstruction,
+            CustomExpression<CustomExpressionInstruction>,
+        >::PrimitiveValue(val),
         operation: None,
     }
     .into();
@@ -324,7 +363,10 @@ fn expression_ast_transform_primitive_value_ptr() {
     assert_eq!(PrimitiveValue::Ptr, expr_val);
     assert_eq!(expr_val.to_string(), "ptr");
     let expr: Expression = ast::Expression {
-        expression_value: ast::ExpressionValue::<CustomExpression>::PrimitiveValue(val),
+        expression_value: ast::ExpressionValue::<
+            CustomExpressionInstruction,
+            CustomExpression<CustomExpressionInstruction>,
+        >::PrimitiveValue(val),
         operation: None,
     }
     .into();
@@ -342,7 +384,10 @@ fn expression_ast_transform_primitive_value_none() {
     assert_eq!(PrimitiveValue::None, expr_val);
     assert_eq!(expr_val.to_string(), "None");
     let expr: Expression = ast::Expression {
-        expression_value: ast::ExpressionValue::<CustomExpression>::PrimitiveValue(val),
+        expression_value: ast::ExpressionValue::<
+            CustomExpressionInstruction,
+            CustomExpression<CustomExpressionInstruction>,
+        >::PrimitiveValue(val),
         operation: None,
     }
     .into();
@@ -363,7 +408,10 @@ fn expression_ast_transform_primitive_struct_value() {
 fn expression_ast_transform_expression() {
     let val = ast::PrimitiveValue::Ptr;
     let sub_expr = ast::Expression {
-        expression_value: ast::ExpressionValue::<CustomExpression>::PrimitiveValue(val),
+        expression_value: ast::ExpressionValue::<
+            CustomExpressionInstruction,
+            CustomExpression<CustomExpressionInstruction>,
+        >::PrimitiveValue(val),
         operation: None,
     };
     let expr: Expression = ast::Expression {
@@ -838,12 +886,12 @@ fn expression_func_call() {
     t.clean_errors();
 
     // Declare function
-    let fn_statement = ast::FunctionStatement {
-        name: fn_name.clone(),
-        parameters: vec![],
-        result_type: ast::Type::Primitive(ast::PrimitiveTypes::Ptr),
-        body: vec![],
-    };
+    let fn_statement = ast::FunctionStatement::new(
+        fn_name.clone(),
+        vec![],
+        ast::Type::Primitive(ast::PrimitiveTypes::Ptr),
+        vec![],
+    );
     t.state.function_declaration(&fn_statement);
     assert!(t.is_empty_error());
 
@@ -1259,63 +1307,91 @@ fn expression_multiple_operation_simple4() {
 
 #[test]
 fn custom_expression() {
+    use semantic_analyzer::semantic::State;
+    use semantic_analyzer::types::semantic::{ExtendedExpression, SemanticContextInstruction};
+
     #[derive(Clone, Debug, PartialEq)]
     pub enum AstCustomExpression {
         GoIn(u32, u32),
         GoOut(u32),
     }
 
-    #[derive(Clone, Debug, PartialEq, Copy)]
-    #[allow(dead_code)]
-    pub enum CustomExpressionInstruction {
-        GoIn {
-            index: u32,
-            value: u64,
-            register_number: u64,
-        },
-        GoOut {
-            value: u64,
-            register_number: u64,
-        },
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct CustomExpression<I: SemanticContextInstruction> {
+        ast: AstCustomExpression,
+        _marker: PhantomData<I>,
     }
 
-    impl SemanticContextInstruction for CustomExpressionInstruction {}
-
-    impl ExtendedExpression for AstCustomExpression {
-        fn expression<I: SemanticContextInstruction>(
-            &self,
-            _state: &mut State<Self, I>,
-            block_state: &Rc<RefCell<BlockState<I>>>,
-        ) -> ExpressionResult {
-            block_state.borrow_mut().inc_register();
-            let register_number = block_state.borrow().last_register_number;
-            let custom_instr = CustomExpressionInstruction::GoIn {
-                index: 0,
-                value: 10,
-                register_number,
-            };
-            //let instr = custom_instr;
-            ExpressionResult {
-                expr_type: Type::Primitive(PrimitiveTypes::U32),
-                expr_value: ExpressionResultValue::Register(register_number),
+    impl<I: SemanticContextInstruction> CustomExpression<I> {
+        fn new(ast: AstCustomExpression) -> Self {
+            Self {
+                ast,
+                _marker: PhantomData,
             }
         }
     }
 
-    let block_state = Rc::new(RefCell::new(BlockState::new(None)));
-    let mut state: State<AstCustomExpression, CustomExpressionInstruction> = State::default();
-    let next_expr = ast::Expression {
+    #[derive(Clone, Debug, PartialEq)]
+    #[allow(dead_code)]
+    pub enum CustomExpressionInstruction {
+        GoIn { index: u32, value: u32 },
+        GoOut { result: u32 },
+    }
+
+    impl SemanticContextInstruction for CustomExpressionInstruction {
+        fn instruction(&self) -> Box<Self> {
+            Box::new(self.clone())
+        }
+    }
+
+    impl ExtendedExpression<CustomExpressionInstruction>
+        for CustomExpression<CustomExpressionInstruction>
+    {
+        fn expression(
+            &self,
+            _state: &mut State<Self, CustomExpressionInstruction>,
+            block_state: &Rc<RefCell<BlockState<CustomExpressionInstruction>>>,
+        ) -> ExpressionResult {
+            block_state.borrow_mut().inc_register();
+            let reg = block_state.borrow().last_register_number;
+            let instr = match self.ast {
+                AstCustomExpression::GoIn(x, y) => {
+                    CustomExpressionInstruction::GoIn { index: x, value: y }
+                }
+                AstCustomExpression::GoOut(x) => CustomExpressionInstruction::GoOut { result: x },
+            };
+            block_state.borrow_mut().extended_expression(&instr);
+            ExpressionResult {
+                expr_type: Type::Primitive(PrimitiveTypes::U32),
+                expr_value: ExpressionResultValue::Register(reg),
+            }
+        }
+    }
+
+    let block_state = Rc::new(RefCell::new(
+        BlockState::<CustomExpressionInstruction>::new(None),
+    ));
+    let mut state: State<
+        CustomExpression<CustomExpressionInstruction>,
+        CustomExpressionInstruction,
+    > = State::default();
+
+    let next_expr = ast::Expression::<
+        CustomExpressionInstruction,
+        CustomExpression<CustomExpressionInstruction>,
+    > {
         expression_value: ast::ExpressionValue::ExtendedExpression(Box::new(
-            AstCustomExpression::GoIn(10, 20),
+            CustomExpression::new(AstCustomExpression::GoIn(10, 20)),
         )),
         operation: None,
     };
     let expr = ast::Expression {
         expression_value: ast::ExpressionValue::ExtendedExpression(Box::new(
-            AstCustomExpression::GoOut(30),
+            CustomExpression::new(AstCustomExpression::GoOut(30)),
         )),
         operation: Some((ast::ExpressionOperations::Plus, Box::new(next_expr))),
     };
+
     let expr_into: Expression = expr.clone().into();
     // For grcov
     format!("{:#?}", expr_into);
@@ -1331,9 +1407,9 @@ fn custom_expression() {
             expr_value: ExpressionResultValue::Register(3),
         }
     );
-    let state = block_state.borrow().get_context().clone().get();
-    assert_eq!(state.len(), 1);
-    println!("{state:#?}");
+    let bs = block_state.borrow().get_context().clone().get();
+    assert_eq!(bs.len(), 3);
+    println!("{bs:#?}");
     /*
     assert_eq!(
         state[0],
@@ -1350,22 +1426,5 @@ fn custom_expression() {
             register_number: 3
         }
     );
-
-       assert_eq!(
-           state[0],
-           SemanticStackContext::ExpressionOperation {
-               operation: ExpressionOperations::Plus,
-               left_value: ExpressionResult {
-                   expr_type: Type::Primitive(PrimitiveTypes::U32),
-                   expr_value: ExpressionResultValue::Register(1)
-               },
-               right_value: ExpressionResult {
-                   expr_type: Type::Primitive(PrimitiveTypes::U32),
-                   expr_value: ExpressionResultValue::Register(2)
-               },
-               register_number: 3
-           }
-       );
-
     */
 }

--- a/tests/expressions_tests.rs
+++ b/tests/expressions_tests.rs
@@ -1409,22 +1409,33 @@ fn custom_expression() {
     );
     let bs = block_state.borrow().get_context().clone().get();
     assert_eq!(bs.len(), 3);
-    println!("{bs:#?}");
-    /*
+
     assert_eq!(
-        state[0],
+        bs[0],
+        SemanticStackContext::ExtendedExpression(Box::new(CustomExpressionInstruction::GoOut {
+            result: 30
+        }))
+    );
+    assert_eq!(
+        bs[1],
+        SemanticStackContext::ExtendedExpression(Box::new(CustomExpressionInstruction::GoIn {
+            index: 10,
+            value: 20,
+        }))
+    );
+    assert_eq!(
+        bs[2],
         SemanticStackContext::ExpressionOperation {
             operation: ExpressionOperations::Plus,
             left_value: ExpressionResult {
                 expr_type: Type::Primitive(PrimitiveTypes::U32),
-                expr_value: ExpressionResultValue::Register(1)
+                expr_value: ExpressionResultValue::Register(1),
             },
             right_value: ExpressionResult {
                 expr_type: Type::Primitive(PrimitiveTypes::U32),
-                expr_value: ExpressionResultValue::Register(2)
+                expr_value: ExpressionResultValue::Register(2),
             },
-            register_number: 3
+            register_number: 3,
         }
     );
-    */
 }

--- a/tests/function_call_tests.rs
+++ b/tests/function_call_tests.rs
@@ -1,4 +1,4 @@
-use crate::utils::{CustomExpression, SemanticTest};
+use crate::utils::{CustomExpression, CustomExpressionInstruction, SemanticTest};
 use semantic_analyzer::ast;
 use semantic_analyzer::ast::{CodeLocation, GetLocation, GetName, Ident};
 use semantic_analyzer::types::block_state::BlockState;
@@ -13,7 +13,10 @@ mod utils;
 #[test]
 fn func_call_transform() {
     let fn_name = ast::FunctionName::new(Ident::new("fn1"));
-    let fn_call = ast::FunctionCall::<CustomExpression> {
+    let fn_call = ast::FunctionCall::<
+        CustomExpressionInstruction,
+        CustomExpression<CustomExpressionInstruction>,
+    > {
         name: fn_name.clone(),
         parameters: vec![],
     };
@@ -25,9 +28,10 @@ fn func_call_transform() {
     assert!(fn_call_into.parameters.is_empty());
 
     let param1 = ast::Expression {
-        expression_value: ast::ExpressionValue::<CustomExpression>::PrimitiveValue(
-            ast::PrimitiveValue::Ptr,
-        ),
+        expression_value: ast::ExpressionValue::<
+            CustomExpressionInstruction,
+            CustomExpression<CustomExpressionInstruction>,
+        >::PrimitiveValue(ast::PrimitiveValue::Ptr),
         operation: None,
     };
     let fn_call2 = ast::FunctionCall {
@@ -71,12 +75,12 @@ fn func_call_wrong_type() {
         name: ast::ParameterName::new(Ident::new("x")),
         parameter_type: ast::Type::Primitive(ast::PrimitiveTypes::Bool),
     };
-    let fn_statement = ast::FunctionStatement {
-        name: fn_name.clone(),
-        parameters: vec![fn_decl_param1],
-        result_type: ast::Type::Primitive(ast::PrimitiveTypes::I16),
-        body: vec![],
-    };
+    let fn_statement = ast::FunctionStatement::new(
+        fn_name.clone(),
+        vec![fn_decl_param1],
+        ast::Type::Primitive(ast::PrimitiveTypes::I16),
+        vec![],
+    );
     t.state.function_declaration(&fn_statement);
     assert!(t.is_empty_error());
 
@@ -107,12 +111,12 @@ fn func_call_declared_func() {
         name: ast::ParameterName::new(Ident::new("x")),
         parameter_type: ast::Type::Primitive(ast::PrimitiveTypes::Bool),
     };
-    let fn_statement = ast::FunctionStatement {
-        name: fn_name.clone(),
-        parameters: vec![fn_decl_param1],
-        result_type: ast::Type::Primitive(ast::PrimitiveTypes::I32),
-        body: vec![],
-    };
+    let fn_statement = ast::FunctionStatement::new(
+        fn_name.clone(),
+        vec![fn_decl_param1],
+        ast::Type::Primitive(ast::PrimitiveTypes::I32),
+        vec![],
+    );
     t.state.function_declaration(&fn_statement);
     assert!(t.is_empty_error());
 

--- a/tests/function_declaration_tests.rs
+++ b/tests/function_declaration_tests.rs
@@ -16,12 +16,12 @@ fn function_transform_ast() {
 fn function_declaration_without_body() {
     let mut t = SemanticTest::new();
     let fn_name = ast::FunctionName::new(Ident::new("fn1"));
-    let fn_statement = ast::FunctionStatement {
-        name: fn_name.clone(),
-        parameters: vec![],
-        result_type: ast::Type::Primitive(ast::PrimitiveTypes::I8),
-        body: vec![],
-    };
+    let fn_statement = ast::FunctionStatement::new(
+        fn_name.clone(),
+        vec![],
+        ast::Type::Primitive(ast::PrimitiveTypes::I8),
+        vec![],
+    );
     t.state.function_declaration(&fn_statement);
     assert!(t.is_empty_error());
     assert!(t.state.global.functions.contains_key(&fn_name.into()));
@@ -53,15 +53,15 @@ fn function_declaration_wrong_type() {
         attributes: vec![],
     };
 
-    let fn_statement = ast::FunctionStatement {
-        name: fn_name.clone(),
-        parameters: vec![ast::FunctionParameter {
+    let fn_statement = ast::FunctionStatement::new(
+        fn_name.clone(),
+        vec![ast::FunctionParameter {
             name: ast::ParameterName::new(Ident::new("x")),
             parameter_type: ast::Type::Primitive(ast::PrimitiveTypes::I64),
         }],
-        result_type: ast::Type::Struct(type_decl.clone()),
-        body: vec![],
-    };
+        ast::Type::Struct(type_decl.clone()),
+        vec![],
+    );
     t.state.function_declaration(&fn_statement);
     assert!(t.check_errors_len(1), "Errors: {:?}", t.state.errors.len());
     assert!(
@@ -78,14 +78,15 @@ fn function_declaration_wrong_type() {
     let state = t.state.global.context.clone().get();
     assert_eq!(state.len(), 0);
 
-    let fn_statement2 = ast::FunctionStatement {
-        parameters: vec![ast::FunctionParameter {
+    let fn_statement2 = ast::FunctionStatement::new(
+        fn_statement.name,
+        vec![ast::FunctionParameter {
             name: ast::ParameterName::new(Ident::new("x")),
             parameter_type: ast::Type::Struct(type_decl.clone()),
         }],
-        result_type: ast::Type::Primitive(ast::PrimitiveTypes::I64),
-        ..fn_statement
-    };
+        ast::Type::Primitive(ast::PrimitiveTypes::I64),
+        fn_statement.body,
+    );
     t.state.function_declaration(&fn_statement2);
     assert!(t.check_errors_len(2), "Errors: {:?}", t.state.errors.len());
     assert!(t.check_error_index(1, StateErrorKind::TypeNotFound));

--- a/tests/if_tests.rs
+++ b/tests/if_tests.rs
@@ -1,4 +1,4 @@
-use crate::utils::{CustomExpression, SemanticTest};
+use crate::utils::{CustomExpression, CustomExpressionInstruction, SemanticTest};
 use semantic_analyzer::ast;
 use semantic_analyzer::ast::{CodeLocation, GetLocation, Ident};
 use semantic_analyzer::types::block_state::BlockState;
@@ -19,9 +19,10 @@ mod utils;
 #[test]
 fn if_single_transform() {
     let if_condition_expr = ast::Expression {
-        expression_value: ast::ExpressionValue::<CustomExpression>::PrimitiveValue(
-            ast::PrimitiveValue::F32(1.2),
-        ),
+        expression_value: ast::ExpressionValue::<
+            CustomExpressionInstruction,
+            CustomExpression<CustomExpressionInstruction>,
+        >::PrimitiveValue(ast::PrimitiveValue::F32(1.2)),
         operation: None,
     };
     let if_condition = ast::IfCondition::Single(if_condition_expr.clone());
@@ -89,7 +90,7 @@ fn if_single_transform() {
             if_fn_call_into.clone(),
             if_if_statement2_into.clone(),
             loop_statement_into.clone(),
-            return_statement_into.clone()
+            return_statement_into.clone(),
         ])
     );
     assert_eq!(
@@ -100,7 +101,7 @@ fn if_single_transform() {
             if_fn_call_into,
             if_if_statement2_into,
             loop_statement_into,
-            return_statement_into
+            return_statement_into,
         ])
     );
     let if_compare1 = *if_statement1_into.clone().else_if_statement.unwrap();
@@ -117,9 +118,10 @@ fn if_single_transform() {
 #[test]
 fn if_logic_transform() {
     let if_condition_expr = ast::Expression {
-        expression_value: ast::ExpressionValue::<CustomExpression>::PrimitiveValue(
-            ast::PrimitiveValue::F32(1.2),
-        ),
+        expression_value: ast::ExpressionValue::<
+            CustomExpressionInstruction,
+            CustomExpression<CustomExpressionInstruction>,
+        >::PrimitiveValue(ast::PrimitiveValue::F32(1.2)),
         operation: None,
     };
     let if_condition_expr_into: Expression = if_condition_expr.clone().into();
@@ -374,8 +376,8 @@ fn if_condition_calculation_simple() {
         ctx[0],
         SemanticStackContext::IfConditionExpression {
             expr_result: ExpressionResult {
-                expr_type: Type::Primitive(PrimitiveTypes::I8,),
-                expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::I8(3,),),
+                expr_type: Type::Primitive(PrimitiveTypes::I8),
+                expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::I8(3)),
             },
             label_if_begin: label_if_begin.clone(),
             label_if_end,
@@ -385,8 +387,8 @@ fn if_condition_calculation_simple() {
         ctx[1],
         SemanticStackContext::IfConditionExpression {
             expr_result: ExpressionResult {
-                expr_type: Type::Primitive(PrimitiveTypes::I8,),
-                expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::I8(3,),),
+                expr_type: Type::Primitive(PrimitiveTypes::I8),
+                expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::I8(3)),
             },
             label_if_begin,
             label_if_end: label_if_else,
@@ -487,11 +489,11 @@ fn if_condition_calculation_logic() {
         SemanticStackContext::ConditionExpression {
             left_result: ExpressionResult {
                 expr_type: Type::Primitive(PrimitiveTypes::I8),
-                expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::I8(3))
+                expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::I8(3)),
             },
             right_result: ExpressionResult {
                 expr_type: Type::Primitive(PrimitiveTypes::I8),
-                expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::I8(6))
+                expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::I8(6)),
             },
             condition: Condition::Eq,
             register_number: 1,
@@ -502,7 +504,7 @@ fn if_condition_calculation_logic() {
         SemanticStackContext::IfConditionLogic {
             label_if_begin: label_if_begin.clone(),
             label_if_end: label_if_end.clone(),
-            result_register: 1
+            result_register: 1,
         }
     );
     assert_eq!(
@@ -510,11 +512,11 @@ fn if_condition_calculation_logic() {
         SemanticStackContext::ConditionExpression {
             left_result: ExpressionResult {
                 expr_type: Type::Primitive(PrimitiveTypes::I8),
-                expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::I8(3))
+                expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::I8(3)),
             },
             right_result: ExpressionResult {
                 expr_type: Type::Primitive(PrimitiveTypes::I8),
-                expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::I8(6))
+                expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::I8(6)),
             },
             condition: Condition::Eq,
             register_number: 2,
@@ -525,7 +527,7 @@ fn if_condition_calculation_logic() {
         SemanticStackContext::IfConditionLogic {
             label_if_begin: label_if_begin.clone(),
             label_if_end: label_if_else,
-            result_register: 2
+            result_register: 2,
         }
     );
     assert_eq!(
@@ -533,11 +535,11 @@ fn if_condition_calculation_logic() {
         SemanticStackContext::ConditionExpression {
             left_result: ExpressionResult {
                 expr_type: Type::Primitive(PrimitiveTypes::I8),
-                expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::I8(3))
+                expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::I8(3)),
             },
             right_result: ExpressionResult {
                 expr_type: Type::Primitive(PrimitiveTypes::I8),
-                expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::I8(6))
+                expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::I8(6)),
             },
             condition: Condition::Eq,
             register_number: 3,
@@ -548,11 +550,11 @@ fn if_condition_calculation_logic() {
         SemanticStackContext::ConditionExpression {
             left_result: ExpressionResult {
                 expr_type: Type::Primitive(PrimitiveTypes::I8),
-                expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::I8(3))
+                expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::I8(3)),
             },
             right_result: ExpressionResult {
                 expr_type: Type::Primitive(PrimitiveTypes::I8),
-                expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::I8(6))
+                expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::I8(6)),
             },
             condition: Condition::Eq,
             register_number: 4,
@@ -564,7 +566,7 @@ fn if_condition_calculation_logic() {
             logic_condition: LogicCondition::Or,
             left_register_result: 3,
             right_register_result: 4,
-            register_number: 5
+            register_number: 5,
         }
     );
     assert_eq!(
@@ -572,7 +574,7 @@ fn if_condition_calculation_logic() {
         SemanticStackContext::IfConditionLogic {
             label_if_begin,
             label_if_end,
-            result_register: 5
+            result_register: 5,
         }
     );
     assert_eq!(ctx.len(), 8);
@@ -683,12 +685,12 @@ fn if_condition_primitive_type_only_check() {
     t.state.types(&type_decl.clone());
 
     let fn_name = ast::FunctionName::new(Ident::new("fn1"));
-    let fn_statement = ast::FunctionStatement {
-        name: fn_name.clone(),
-        parameters: vec![],
-        result_type: ast::Type::Struct(type_decl),
-        body: vec![],
-    };
+    let fn_statement = ast::FunctionStatement::new(
+        fn_name.clone(),
+        vec![],
+        ast::Type::Struct(type_decl),
+        vec![],
+    );
     t.state.function_declaration(&fn_statement);
 
     // Left expression return error - function not found
@@ -810,7 +812,7 @@ fn else_if_statement() {
                 expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::U64(1)),
             },
             label_if_begin: String::from("if_begin").into(),
-            label_if_end: String::from("if_else").into()
+            label_if_end: String::from("if_else").into(),
         }
     );
     assert_eq!(ctx1[0], main_ctx[0]);
@@ -856,7 +858,7 @@ fn else_if_statement() {
                 expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::U64(2)),
             },
             label_if_begin: String::from("if_begin.0").into(),
-            label_if_end: String::from("if_else.0").into()
+            label_if_end: String::from("if_else.0").into(),
         }
     );
     assert_eq!(ctx2[0], main_ctx[4]);
@@ -908,15 +910,15 @@ fn if_body_statements() {
         operation: None,
     };
 
-    let fn2 = ast::FunctionStatement {
-        name: ast::FunctionName::new(Ident::new("fn2")),
-        parameters: vec![],
-        result_type: ast::Type::Primitive(ast::PrimitiveTypes::U16),
-        body: vec![ast::BodyStatement::Expression(ast::Expression {
+    let fn2 = ast::FunctionStatement::new(
+        ast::FunctionName::new(Ident::new("fn2")),
+        vec![],
+        ast::Type::Primitive(ast::PrimitiveTypes::U16),
+        vec![ast::BodyStatement::Expression(ast::Expression {
             expression_value: ast::ExpressionValue::PrimitiveValue(ast::PrimitiveValue::U16(23)),
             operation: None,
         })],
-    };
+    );
     t.state.function_declaration(&fn2);
 
     let if_body_let_binding = ast::IfBodyStatement::LetBinding(ast::LetBinding {
@@ -1014,7 +1016,7 @@ fn if_body_statements() {
                 expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::Bool(true)),
             },
             label_if_begin: String::from("if_begin.0").into(),
-            label_if_end: String::from("if_end").into()
+            label_if_end: String::from("if_end").into(),
         }
     );
     assert_eq!(
@@ -1032,7 +1034,7 @@ fn if_body_statements() {
                 parameters: vec![],
             },
             params: vec![],
-            register_number: 2
+            register_number: 2,
         }
     );
     assert_eq!(
@@ -1070,7 +1072,7 @@ fn if_body_statements() {
                 parameters: vec![],
             },
             params: vec![],
-            register_number: 3
+            register_number: 3,
         }
     );
     assert_eq!(
@@ -1097,7 +1099,7 @@ fn if_body_statements() {
                 expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::U64(1)),
             },
             label_if_begin: String::from("if_begin").into(),
-            label_if_end: String::from("if_end").into()
+            label_if_end: String::from("if_end").into(),
         }
     );
     assert_eq!(
@@ -1114,7 +1116,7 @@ fn if_body_statements() {
                 inner_type: Type::Primitive(PrimitiveTypes::Bool),
                 mutable: true,
                 alloca: false,
-                malloc: false
+                malloc: false,
             },
             expr_result: ExpressionResult {
                 expr_type: Type::Primitive(PrimitiveTypes::Bool),
@@ -1130,7 +1132,7 @@ fn if_body_statements() {
                 inner_type: Type::Primitive(PrimitiveTypes::Bool),
                 mutable: true,
                 alloca: false,
-                malloc: false
+                malloc: false,
             },
             expr_result: ExpressionResult {
                 expr_type: Type::Primitive(PrimitiveTypes::Bool),
@@ -1147,7 +1149,7 @@ fn if_body_statements() {
                 parameters: vec![],
             },
             params: vec![],
-            register_number: 1
+            register_number: 1,
         }
     );
     assert_eq!(stm_ctx[5], ctx1[0]);
@@ -1185,25 +1187,25 @@ fn if_loop_body_statements() {
         operation: None,
     };
 
-    let fn2 = ast::FunctionStatement {
-        name: ast::FunctionName::new(Ident::new("fn2")),
-        parameters: vec![],
-        result_type: ast::Type::Primitive(ast::PrimitiveTypes::U16),
-        body: vec![ast::BodyStatement::Expression(ast::Expression {
+    let fn2 = ast::FunctionStatement::new(
+        ast::FunctionName::new(Ident::new("fn2")),
+        vec![],
+        ast::Type::Primitive(ast::PrimitiveTypes::U16),
+        vec![ast::BodyStatement::Expression(ast::Expression {
             expression_value: ast::ExpressionValue::PrimitiveValue(ast::PrimitiveValue::U16(23)),
             operation: None,
         })],
-    };
+    );
     t.state.function_declaration(&fn2);
-    let fn3 = ast::FunctionStatement {
-        name: ast::FunctionName::new(Ident::new("fn3")),
-        parameters: vec![],
-        result_type: ast::Type::Primitive(ast::PrimitiveTypes::I16),
-        body: vec![ast::BodyStatement::Expression(ast::Expression {
+    let fn3 = ast::FunctionStatement::new(
+        ast::FunctionName::new(Ident::new("fn3")),
+        vec![],
+        ast::Type::Primitive(ast::PrimitiveTypes::I16),
+        vec![ast::BodyStatement::Expression(ast::Expression {
             expression_value: ast::ExpressionValue::PrimitiveValue(ast::PrimitiveValue::I16(32)),
             operation: None,
         })],
-    };
+    );
     t.state.function_declaration(&fn3);
 
     let if_body_let_binding = ast::IfLoopBodyStatement::LetBinding(ast::LetBinding {
@@ -1302,7 +1304,7 @@ fn if_loop_body_statements() {
                 expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::Bool(true)),
             },
             label_if_begin: String::from("if_begin.0").into(),
-            label_if_end: String::from("if_end").into()
+            label_if_end: String::from("if_end").into(),
         }
     );
     assert_eq!(
@@ -1320,7 +1322,7 @@ fn if_loop_body_statements() {
                 parameters: vec![],
             },
             params: vec![],
-            register_number: 2
+            register_number: 2,
         }
     );
     assert_eq!(
@@ -1357,7 +1359,7 @@ fn if_loop_body_statements() {
                 parameters: vec![],
             },
             params: vec![],
-            register_number: 3
+            register_number: 3,
         }
     );
     assert_eq!(
@@ -1384,7 +1386,7 @@ fn if_loop_body_statements() {
                 expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::U64(1)),
             },
             label_if_begin: String::from("if_begin").into(),
-            label_if_end: String::from("if_end").into()
+            label_if_end: String::from("if_end").into(),
         }
     );
     assert_eq!(
@@ -1401,7 +1403,7 @@ fn if_loop_body_statements() {
                 inner_type: Type::Primitive(PrimitiveTypes::Bool),
                 mutable: true,
                 alloca: false,
-                malloc: false
+                malloc: false,
             },
             expr_result: ExpressionResult {
                 expr_type: Type::Primitive(PrimitiveTypes::Bool),
@@ -1417,7 +1419,7 @@ fn if_loop_body_statements() {
                 inner_type: Type::Primitive(PrimitiveTypes::Bool),
                 mutable: true,
                 alloca: false,
-                malloc: false
+                malloc: false,
             },
             expr_result: ExpressionResult {
                 expr_type: Type::Primitive(PrimitiveTypes::Bool),
@@ -1434,7 +1436,7 @@ fn if_loop_body_statements() {
                 parameters: vec![],
             },
             params: vec![],
-            register_number: 1
+            register_number: 1,
         }
     );
     assert_eq!(stm_ctx[5], ctx1[0]);

--- a/tests/let_binding_tests.rs
+++ b/tests/let_binding_tests.rs
@@ -1,4 +1,4 @@
-use crate::utils::{CustomExpression, SemanticTest};
+use crate::utils::{CustomExpression, CustomExpressionInstruction, SemanticTest};
 use semantic_analyzer::ast;
 use semantic_analyzer::ast::{CodeLocation, GetLocation, GetName, Ident};
 use semantic_analyzer::types::block_state::BlockState;
@@ -15,9 +15,10 @@ mod utils;
 #[test]
 fn let_binding_transform() {
     let expr_ast = ast::Expression {
-        expression_value: ast::ExpressionValue::<CustomExpression>::PrimitiveValue(
-            ast::PrimitiveValue::U64(3),
-        ),
+        expression_value: ast::ExpressionValue::<
+            CustomExpressionInstruction,
+            CustomExpression<CustomExpressionInstruction>,
+        >::PrimitiveValue(ast::PrimitiveValue::U64(3)),
         operation: None,
     };
     let let_binding_ast = ast::LetBinding {

--- a/tests/loop_tests.rs
+++ b/tests/loop_tests.rs
@@ -1,4 +1,4 @@
-use crate::utils::{CustomExpression, SemanticTest};
+use crate::utils::{CustomExpression, CustomExpressionInstruction, SemanticTest};
 use semantic_analyzer::ast;
 use semantic_analyzer::ast::Ident;
 use semantic_analyzer::types::block_state::BlockState;
@@ -20,9 +20,10 @@ fn loop_transform() {
         mutable: false,
         value_type: None,
         value: Box::new(ast::Expression {
-            expression_value: ast::ExpressionValue::<CustomExpression>::PrimitiveValue(
-                ast::PrimitiveValue::Bool(true),
-            ),
+            expression_value: ast::ExpressionValue::<
+                CustomExpressionInstruction,
+                CustomExpression<CustomExpressionInstruction>,
+            >::PrimitiveValue(ast::PrimitiveValue::Bool(true)),
             operation: None,
         }),
     };
@@ -76,11 +77,19 @@ fn loop_transform() {
             LoopBodyStatement::Return(val) => assert_eq!(val, return_statement.clone().into()),
             LoopBodyStatement::Break => assert_eq!(
                 LoopBodyStatement::Break,
-                ast::LoopBodyStatement::<CustomExpression>::Break.into()
+                ast::LoopBodyStatement::<
+                    CustomExpressionInstruction,
+                    CustomExpression<CustomExpressionInstruction>,
+                >::Break
+                    .into()
             ),
             LoopBodyStatement::Continue => assert_eq!(
                 LoopBodyStatement::Continue,
-                ast::LoopBodyStatement::<CustomExpression>::Continue.into()
+                ast::LoopBodyStatement::<
+                    CustomExpressionInstruction,
+                    CustomExpression<CustomExpressionInstruction>,
+                >::Continue
+                    .into()
             ),
         }
     }
@@ -91,15 +100,15 @@ fn loop_statements() {
     let block_state = Rc::new(RefCell::new(BlockState::new(None)));
     let mut t = SemanticTest::new();
 
-    let fn2 = ast::FunctionStatement {
-        name: ast::FunctionName::new(Ident::new("fn2")),
-        parameters: vec![],
-        result_type: ast::Type::Primitive(ast::PrimitiveTypes::U16),
-        body: vec![ast::BodyStatement::Expression(ast::Expression {
+    let fn2 = ast::FunctionStatement::new(
+        ast::FunctionName::new(Ident::new("fn2")),
+        vec![],
+        ast::Type::Primitive(ast::PrimitiveTypes::U16),
+        vec![ast::BodyStatement::Expression(ast::Expression {
             expression_value: ast::ExpressionValue::PrimitiveValue(ast::PrimitiveValue::U16(23)),
             operation: None,
         })],
-    };
+    );
     t.state.function_declaration(&fn2);
 
     let loop_body_let_binding = ast::LoopBodyStatement::LetBinding(ast::LetBinding {
@@ -179,7 +188,7 @@ fn loop_statements() {
                 expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::Bool(true)),
             },
             label_if_begin: String::from("if_begin").into(),
-            label_if_end: String::from("if_end").into()
+            label_if_end: String::from("if_end").into(),
         }
     );
     assert_eq!(
@@ -197,7 +206,7 @@ fn loop_statements() {
                 parameters: vec![],
             },
             params: vec![],
-            register_number: 2
+            register_number: 2,
         }
     );
     assert_eq!(
@@ -240,7 +249,7 @@ fn loop_statements() {
                 parameters: vec![],
             },
             params: vec![],
-            register_number: 3
+            register_number: 3,
         }
     );
     assert_eq!(
@@ -279,7 +288,7 @@ fn loop_statements() {
                 inner_type: Type::Primitive(PrimitiveTypes::Bool),
                 mutable: true,
                 alloca: false,
-                malloc: false
+                malloc: false,
             },
             expr_result: ExpressionResult {
                 expr_type: Type::Primitive(PrimitiveTypes::Bool),
@@ -295,7 +304,7 @@ fn loop_statements() {
                 inner_type: Type::Primitive(PrimitiveTypes::Bool),
                 mutable: true,
                 alloca: false,
-                malloc: false
+                malloc: false,
             },
             expr_result: ExpressionResult {
                 expr_type: Type::Primitive(PrimitiveTypes::Bool),
@@ -483,7 +492,7 @@ fn loop_statements_with_return_invocation() {
                 inner_type: Type::Primitive(PrimitiveTypes::Bool),
                 mutable: true,
                 alloca: false,
-                malloc: false
+                malloc: false,
             },
             expr_result: ExpressionResult {
                 expr_type: Type::Primitive(PrimitiveTypes::Bool),

--- a/tests/main_tests.rs
+++ b/tests/main_tests.rs
@@ -1,4 +1,4 @@
-use crate::utils::{CustomExpression, SemanticTest};
+use crate::utils::{CustomExpression, CustomExpressionInstruction, SemanticTest};
 use semantic_analyzer::ast::{self, GetName, Ident};
 use semantic_analyzer::types::error::StateErrorKind;
 use semantic_analyzer::types::expression::ExpressionOperations;
@@ -79,11 +79,11 @@ fn main_run() {
         expression_value: ast::ExpressionValue::PrimitiveValue(ast::PrimitiveValue::Bool(true)),
         operation: None,
     });
-    let fn1 = ast::FunctionStatement {
-        name: ast::FunctionName::new(Ident::new("fn1")),
-        parameters: vec![],
-        result_type: ast::Type::Primitive(ast::PrimitiveTypes::Bool),
-        body: vec![
+    let fn1 = ast::FunctionStatement::new(
+        ast::FunctionName::new(Ident::new("fn1")),
+        vec![],
+        ast::Type::Primitive(ast::PrimitiveTypes::Bool),
+        vec![
             body_let_binding,
             body_binding,
             body_fn_call,
@@ -91,22 +91,24 @@ fn main_run() {
             body_loop,
             body_return.clone(),
         ],
-    };
+    );
     let fn_stm = ast::MainStatement::Function(fn1.clone());
 
     let body_expr_return = ast::BodyStatement::Expression(ast::Expression {
         expression_value: ast::ExpressionValue::PrimitiveValue(ast::PrimitiveValue::U16(23)),
         operation: None,
     });
-    let fn2 = ast::FunctionStatement {
-        name: ast::FunctionName::new(Ident::new("fn2")),
-        parameters: vec![],
-        result_type: ast::Type::Primitive(ast::PrimitiveTypes::U16),
-        body: vec![body_expr_return],
-    };
+    let fn2 = ast::FunctionStatement::new(
+        ast::FunctionName::new(Ident::new("fn2")),
+        vec![],
+        ast::Type::Primitive(ast::PrimitiveTypes::U16),
+        vec![body_expr_return],
+    );
     let fn2_stm = ast::MainStatement::Function(fn2.clone());
-    let main_stm: ast::Main<CustomExpression> =
-        vec![import_stm, constant_stm, ty_stm, fn_stm, fn2_stm];
+    let main_stm: ast::Main<
+        CustomExpressionInstruction,
+        CustomExpression<CustomExpressionInstruction>,
+    > = vec![import_stm, constant_stm, ty_stm, fn_stm, fn2_stm];
     // For grcov
     format!("{main_stm:#?}");
     t.state.run(&main_stm);
@@ -174,7 +176,7 @@ fn main_run() {
                 expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::Bool(true)),
             },
             label_if_begin: String::from("if_begin").into(),
-            label_if_end: String::from("if_end").into()
+            label_if_end: String::from("if_end").into(),
         }
     );
     assert_eq!(
@@ -192,7 +194,7 @@ fn main_run() {
                 parameters: vec![],
             },
             params: vec![],
-            register_number: 2
+            register_number: 2,
         }
     );
     assert_eq!(
@@ -231,7 +233,7 @@ fn main_run() {
                 parameters: vec![],
             },
             params: vec![],
-            register_number: 3
+            register_number: 3,
         }
     );
     assert_eq!(
@@ -286,7 +288,7 @@ fn main_run() {
                 inner_type: Type::Primitive(PrimitiveTypes::Bool),
                 mutable: true,
                 alloca: false,
-                malloc: false
+                malloc: false,
             },
             expr_result: ExpressionResult {
                 expr_type: Type::Primitive(PrimitiveTypes::Bool),
@@ -302,7 +304,7 @@ fn main_run() {
                 inner_type: Type::Primitive(PrimitiveTypes::Bool),
                 mutable: true,
                 alloca: false,
-                malloc: false
+                malloc: false,
             },
             expr_result: ExpressionResult {
                 expr_type: Type::Primitive(PrimitiveTypes::Bool),
@@ -319,7 +321,7 @@ fn main_run() {
                 parameters: vec![],
             },
             params: vec![],
-            register_number: 1
+            register_number: 1,
         }
     );
     assert_eq!(st_ctx1[3], st_ch_ctx1[0]);
@@ -354,14 +356,17 @@ fn double_return() {
         expression_value: ast::ExpressionValue::PrimitiveValue(ast::PrimitiveValue::Bool(true)),
         operation: None,
     });
-    let fn1 = ast::FunctionStatement {
-        name: ast::FunctionName::new(Ident::new("fn1")),
-        parameters: vec![],
-        result_type: ast::Type::Primitive(ast::PrimitiveTypes::Bool),
-        body: vec![body_return, body_expr],
-    };
+    let fn1 = ast::FunctionStatement::new(
+        ast::FunctionName::new(Ident::new("fn1")),
+        vec![],
+        ast::Type::Primitive(ast::PrimitiveTypes::Bool),
+        vec![body_return, body_expr],
+    );
     let fn_stm = ast::MainStatement::Function(fn1);
-    let main_stm: ast::Main<CustomExpression> = vec![fn_stm];
+    let main_stm: ast::Main<
+        CustomExpressionInstruction,
+        CustomExpression<CustomExpressionInstruction>,
+    > = vec![fn_stm];
     t.state.run(&main_stm);
     assert!(t.check_errors_len(2), "Errors: {:?}", t.state.errors.len());
     assert!(t.check_error_index(0, StateErrorKind::ForbiddenCodeAfterReturnDeprecated));
@@ -375,14 +380,17 @@ fn wrong_return_type() {
         expression_value: ast::ExpressionValue::PrimitiveValue(ast::PrimitiveValue::I8(10)),
         operation: None,
     });
-    let fn1 = ast::FunctionStatement {
-        name: ast::FunctionName::new(Ident::new("fn1")),
-        parameters: vec![],
-        result_type: ast::Type::Primitive(ast::PrimitiveTypes::Bool),
-        body: vec![body_return],
-    };
+    let fn1 = ast::FunctionStatement::new(
+        ast::FunctionName::new(Ident::new("fn1")),
+        vec![],
+        ast::Type::Primitive(ast::PrimitiveTypes::Bool),
+        vec![body_return],
+    );
     let fn_stm = ast::MainStatement::Function(fn1);
-    let main_stm: ast::Main<CustomExpression> = vec![fn_stm];
+    let main_stm: ast::Main<
+        CustomExpressionInstruction,
+        CustomExpression<CustomExpressionInstruction>,
+    > = vec![fn_stm];
     t.state.run(&main_stm);
     assert!(t.check_errors_len(1), "Errors: {:?}", t.state.errors.len());
     assert!(
@@ -399,14 +407,17 @@ fn expression_as_return() {
         expression_value: ast::ExpressionValue::PrimitiveValue(ast::PrimitiveValue::Bool(true)),
         operation: None,
     });
-    let fn1 = ast::FunctionStatement {
-        name: ast::FunctionName::new(Ident::new("fn1")),
-        parameters: vec![],
-        result_type: ast::Type::Primitive(ast::PrimitiveTypes::Bool),
-        body: vec![body_expr],
-    };
+    let fn1 = ast::FunctionStatement::new(
+        ast::FunctionName::new(Ident::new("fn1")),
+        vec![],
+        ast::Type::Primitive(ast::PrimitiveTypes::Bool),
+        vec![body_expr],
+    );
     let fn_stm = ast::MainStatement::Function(fn1.clone());
-    let main_stm: ast::Main<CustomExpression> = vec![fn_stm];
+    let main_stm: ast::Main<
+        CustomExpressionInstruction,
+        CustomExpression<CustomExpressionInstruction>,
+    > = vec![fn_stm];
     t.state.run(&main_stm);
     assert!(t.is_empty_error());
 
@@ -461,14 +472,17 @@ fn if_return_from_function() {
         else_statement: None,
         else_if_statement: None,
     });
-    let fn1 = ast::FunctionStatement {
-        name: ast::FunctionName::new(Ident::new("fn1")),
-        parameters: vec![],
-        result_type: ast::Type::Primitive(ast::PrimitiveTypes::I8),
-        body: vec![body_if, body_expr_return],
-    };
+    let fn1 = ast::FunctionStatement::new(
+        ast::FunctionName::new(Ident::new("fn1")),
+        vec![],
+        ast::Type::Primitive(ast::PrimitiveTypes::I8),
+        vec![body_if, body_expr_return],
+    );
     let fn_stm = ast::MainStatement::Function(fn1.clone());
-    let main_stm: ast::Main<CustomExpression> = vec![fn_stm];
+    let main_stm: ast::Main<
+        CustomExpressionInstruction,
+        CustomExpression<CustomExpressionInstruction>,
+    > = vec![fn_stm];
     t.state.run(&main_stm);
     assert!(t.is_empty_error());
 
@@ -494,7 +508,7 @@ fn if_return_from_function() {
                 expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::Bool(true)),
             },
             label_if_begin: String::from("if_begin").into(),
-            label_if_end: String::from("if_end").into()
+            label_if_end: String::from("if_end").into(),
         }
     );
     assert_eq!(
@@ -576,14 +590,17 @@ fn function_args_and_let_binding() {
         name: ast::ParameterName::new(Ident::new("x")),
         parameter_type: ast::Type::Primitive(ast::PrimitiveTypes::U64),
     };
-    let fn1 = ast::FunctionStatement {
-        name: ast::FunctionName::new(Ident::new("fn1")),
-        parameters: vec![fn_param1.clone()],
-        result_type: ast::Type::Primitive(ast::PrimitiveTypes::U64),
-        body: vec![body_let_binding, body_expr_return],
-    };
+    let fn1 = ast::FunctionStatement::new(
+        ast::FunctionName::new(Ident::new("fn1")),
+        vec![fn_param1.clone()],
+        ast::Type::Primitive(ast::PrimitiveTypes::U64),
+        vec![body_let_binding, body_expr_return],
+    );
     let fn_stm = ast::MainStatement::Function(fn1.clone());
-    let main_stm: ast::Main<CustomExpression> = vec![fn_stm];
+    let main_stm: ast::Main<
+        CustomExpressionInstruction,
+        CustomExpression<CustomExpressionInstruction>,
+    > = vec![fn_stm];
     t.state.run(&main_stm);
     assert!(t.is_empty_error());
 
@@ -612,14 +629,14 @@ fn function_args_and_let_binding() {
         stm_ctx[0],
         SemanticStackContext::FunctionArg {
             value: value_x.clone(),
-            func_arg: fn_param1.into()
+            func_arg: fn_param1.into(),
         }
     );
     assert_eq!(
         stm_ctx[1],
         SemanticStackContext::ExpressionValue {
             expression: value_x,
-            register_number: 1
+            register_number: 1,
         }
     );
     assert_eq!(
@@ -628,13 +645,13 @@ fn function_args_and_let_binding() {
             operation: ExpressionOperations::Plus,
             left_value: ExpressionResult {
                 expr_type: ty.clone(),
-                expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::U64(23))
+                expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::U64(23)),
             },
             right_value: ExpressionResult {
                 expr_type: ty.clone(),
-                expr_value: ExpressionResultValue::Register(1)
+                expr_value: ExpressionResultValue::Register(1),
             },
-            register_number: 2
+            register_number: 2,
         }
     );
     assert_eq!(
@@ -651,7 +668,7 @@ fn function_args_and_let_binding() {
         stm_ctx[4],
         SemanticStackContext::ExpressionValue {
             expression: value_y,
-            register_number: 3
+            register_number: 3,
         }
     );
     assert_eq!(
@@ -698,14 +715,17 @@ fn function_args_duplication() {
         parameter_type: ast::Type::Primitive(ast::PrimitiveTypes::U64),
     };
     let fn_param2 = fn_param1.clone();
-    let fn1 = ast::FunctionStatement {
-        name: ast::FunctionName::new(Ident::new("fn1")),
-        parameters: vec![fn_param1.clone(), fn_param2.clone()],
-        result_type: ast::Type::Primitive(ast::PrimitiveTypes::U64),
-        body: vec![body_expr_return],
-    };
+    let fn1 = ast::FunctionStatement::new(
+        ast::FunctionName::new(Ident::new("fn1")),
+        vec![fn_param1.clone(), fn_param2.clone()],
+        ast::Type::Primitive(ast::PrimitiveTypes::U64),
+        vec![body_expr_return],
+    );
     let fn_stm = ast::MainStatement::Function(fn1.clone());
-    let main_stm: ast::Main<CustomExpression> = vec![fn_stm];
+    let main_stm: ast::Main<
+        CustomExpressionInstruction,
+        CustomExpression<CustomExpressionInstruction>,
+    > = vec![fn_stm];
     t.state.run(&main_stm);
     assert!(t.check_errors_len(1));
     assert!(t.check_error(StateErrorKind::FunctionArgumentNameDuplicated));

--- a/tests/state_tests.rs
+++ b/tests/state_tests.rs
@@ -5,7 +5,7 @@ use semantic_analyzer::types::condition::{Condition, LogicCondition};
 use semantic_analyzer::types::expression::{
     ExpressionOperations, ExpressionResult, ExpressionResultValue,
 };
-use semantic_analyzer::types::semantic::{ExtendedSemanticContext, SemanticContext};
+use semantic_analyzer::types::semantic::SemanticContext;
 use semantic_analyzer::types::{
     block_state::BlockState,
     semantic::SemanticStack,
@@ -239,7 +239,7 @@ fn block_state_last_register_inc() {
 }
 
 #[test]
-fn zblock_state_instructions_with_parent() {
+fn block_state_instructions_with_parent() {
     let parent_bst = Rc::new(RefCell::new(BlockState::<CustomExpression>::new(None)));
     let mut bst = BlockState::new(Some(parent_bst.clone()));
     let val = Value {
@@ -292,9 +292,6 @@ fn zblock_state_instructions_with_parent() {
     };
     bst.function_arg(val, func_arg);
 
-    let custom_expr = CustomExpression;
-    bst.extended_expression(&custom_expr);
-
     let parent_ctx = parent_bst.borrow().get_context().get();
-    assert_eq!(parent_ctx.len(), 18);
+    assert_eq!(parent_ctx.len(), 17);
 }

--- a/tests/state_tests.rs
+++ b/tests/state_tests.rs
@@ -251,7 +251,7 @@ fn block_state_last_register_inc() {
 }
 
 #[test]
-fn zblock_state_instructions_with_parent() {
+fn block_state_instructions_with_parent() {
     let parent_bst = Rc::new(RefCell::new(
         BlockState::<CustomExpressionInstruction>::new(None),
     ));

--- a/tests/state_tests.rs
+++ b/tests/state_tests.rs
@@ -1,11 +1,11 @@
-use crate::utils::CustomExpression;
+use crate::utils::{CustomExpression, CustomExpressionInstruction};
 use semantic_analyzer::ast::{self, Ident};
 use semantic_analyzer::semantic::State;
 use semantic_analyzer::types::condition::{Condition, LogicCondition};
 use semantic_analyzer::types::expression::{
     ExpressionOperations, ExpressionResult, ExpressionResultValue,
 };
-use semantic_analyzer::types::semantic::SemanticContext;
+use semantic_analyzer::types::semantic::{ExtendedSemanticContext, SemanticContext};
 use semantic_analyzer::types::{
     block_state::BlockState,
     semantic::SemanticStack,
@@ -20,7 +20,7 @@ mod utils;
 
 #[test]
 fn state_init() {
-    let st = State::<CustomExpression, CustomExpression>::default();
+    let st = State::<CustomExpression<CustomExpressionInstruction>, CustomExpressionInstruction>::default();
     // For grcov
     format!("{st:?}");
     assert!(st.global.types.is_empty());
@@ -35,16 +35,16 @@ fn state_init() {
 fn state_block_state_count() {
     let bst1 = Rc::new(RefCell::new(BlockState::new(None)));
     let bst2 = Rc::new(RefCell::new(BlockState::new(Some(bst1.clone()))));
-    let mut st1 = State::<CustomExpression, CustomExpression>::default();
+    let mut st1 = State::<CustomExpression<CustomExpressionInstruction>, CustomExpressionInstruction>::default();
     st1.context.push(bst1);
     st1.context.push(bst2);
     assert_eq!(st1.context.len(), 2);
-    let fs = ast::FunctionStatement {
-        name: ast::FunctionName::new(Ident::new("fn1")),
-        result_type: ast::Type::Primitive(ast::PrimitiveTypes::Bool),
-        parameters: vec![],
-        body: vec![],
-    };
+    let fs = ast::FunctionStatement::new(
+        ast::FunctionName::new(Ident::new("fn1")),
+        vec![],
+        ast::Type::Primitive(ast::PrimitiveTypes::Bool),
+        vec![],
+    );
     st1.function_body(&fs);
     // Should contain error
     assert_eq!(st1.errors.len(), 1);
@@ -53,7 +53,7 @@ fn state_block_state_count() {
 
 #[test]
 fn block_state_fields() {
-    let mut bst: BlockState<CustomExpression> = BlockState::new(None);
+    let mut bst: BlockState<CustomExpressionInstruction> = BlockState::new(None);
     assert!(bst.values.is_empty());
     assert!(bst.inner_values_name.is_empty());
     assert!(bst.labels.is_empty());
@@ -64,10 +64,12 @@ fn block_state_fields() {
     bst.set_child(Rc::new(RefCell::new(BlockState::new(None))));
     assert_eq!(bst.children.len(), 1);
 
-    let bst1 = Rc::new(RefCell::new(BlockState::<CustomExpression>::new(None)));
-    let bst2 = Rc::new(RefCell::new(BlockState::<CustomExpression>::new(Some(
-        bst1.clone(),
-    ))));
+    let bst1 = Rc::new(RefCell::new(
+        BlockState::<CustomExpressionInstruction>::new(None),
+    ));
+    let bst2 = Rc::new(RefCell::new(
+        BlockState::<CustomExpressionInstruction>::new(Some(bst1.clone())),
+    ));
     bst1.borrow_mut().set_child(bst1.clone());
     bst2.borrow_mut().set_return();
     assert!(bst1.borrow().manual_return);
@@ -87,7 +89,9 @@ fn inner_value_name_transform() {
 
 #[test]
 fn block_state_inner_value_name() {
-    let bst1 = Rc::new(RefCell::new(BlockState::<CustomExpression>::new(None)));
+    let bst1 = Rc::new(RefCell::new(
+        BlockState::<CustomExpressionInstruction>::new(None),
+    ));
     let bst2 = Rc::new(RefCell::new(BlockState::new(Some(bst1.clone()))));
     bst1.borrow_mut().set_child(bst1.clone());
     assert!(bst2.borrow().parent.is_some());
@@ -157,7 +161,9 @@ fn block_state_inner_value_name() {
 
 #[test]
 fn block_state_label_name() {
-    let bst1 = Rc::new(RefCell::new(BlockState::<CustomExpression>::new(None)));
+    let bst1 = Rc::new(RefCell::new(
+        BlockState::<CustomExpressionInstruction>::new(None),
+    ));
     let bst2 = Rc::new(RefCell::new(BlockState::new(Some(bst1.clone()))));
     bst1.borrow_mut().set_child(bst1.clone());
 
@@ -189,11 +195,15 @@ fn block_state_label_name() {
 
 #[test]
 fn block_state_value() {
-    let bst1 = Rc::new(RefCell::new(BlockState::<CustomExpression>::new(None)));
-    let bst2 = Rc::new(RefCell::new(BlockState::<CustomExpression>::new(Some(
-        bst1.clone(),
-    ))));
-    let bst3 = Rc::new(RefCell::new(BlockState::<CustomExpression>::new(None)));
+    let bst1 = Rc::new(RefCell::new(
+        BlockState::<CustomExpressionInstruction>::new(None),
+    ));
+    let bst2 = Rc::new(RefCell::new(
+        BlockState::<CustomExpressionInstruction>::new(Some(bst1.clone())),
+    ));
+    let bst3 = Rc::new(RefCell::new(
+        BlockState::<CustomExpressionInstruction>::new(None),
+    ));
     bst1.borrow_mut().set_child(bst1.clone());
 
     // Insert Value
@@ -219,11 +229,13 @@ fn block_state_value() {
 
 #[test]
 fn block_state_last_register_inc() {
-    let bst1 = Rc::new(RefCell::new(BlockState::<CustomExpression>::new(None)));
-    let bst2 = Rc::new(RefCell::new(BlockState::<CustomExpression>::new(Some(
-        bst1.clone(),
-    ))));
-    let mut bst3: BlockState<CustomExpression> = BlockState::new(None);
+    let bst1 = Rc::new(RefCell::new(
+        BlockState::<CustomExpressionInstruction>::new(None),
+    ));
+    let bst2 = Rc::new(RefCell::new(
+        BlockState::<CustomExpressionInstruction>::new(Some(bst1.clone())),
+    ));
+    let mut bst3: BlockState<CustomExpressionInstruction> = BlockState::new(None);
 
     assert_eq!(bst1.borrow().last_register_number, 0);
     assert_eq!(bst2.borrow().last_register_number, 0);
@@ -239,8 +251,10 @@ fn block_state_last_register_inc() {
 }
 
 #[test]
-fn block_state_instructions_with_parent() {
-    let parent_bst = Rc::new(RefCell::new(BlockState::<CustomExpression>::new(None)));
+fn zblock_state_instructions_with_parent() {
+    let parent_bst = Rc::new(RefCell::new(
+        BlockState::<CustomExpressionInstruction>::new(None),
+    ));
     let mut bst = BlockState::new(Some(parent_bst.clone()));
     let val = Value {
         inner_name: String::from("x").into(),
@@ -292,6 +306,9 @@ fn block_state_instructions_with_parent() {
     };
     bst.function_arg(val, func_arg);
 
+    let custom_instr = CustomExpressionInstruction;
+    bst.extended_expression(&custom_instr);
+
     let parent_ctx = parent_bst.borrow().get_context().get();
-    assert_eq!(parent_ctx.len(), 17);
+    assert_eq!(parent_ctx.len(), 18);
 }

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -34,11 +34,7 @@ impl<I: SemanticContextInstruction> ExtendedExpression<I> for CustomExpression<I
 #[cfg_attr(feature = "codec", derive(Serialize, Deserialize))]
 pub struct CustomExpressionInstruction;
 
-impl SemanticContextInstruction for CustomExpressionInstruction {
-    fn instruction(&self) -> Box<Self> {
-        Box::new(Self)
-    }
-}
+impl SemanticContextInstruction for CustomExpressionInstruction {}
 
 pub struct SemanticTest<I: SemanticContextInstruction> {
     pub state: State<CustomExpression<I>, I>,

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -27,11 +27,7 @@ impl ExtendedExpression for CustomExpression {
     }
 }
 
-impl SemanticContextInstruction for CustomExpression {
-    fn instruction(&self) -> Box<Self> {
-        Box::new(Self)
-    }
-}
+impl SemanticContextInstruction for CustomExpression {}
 
 pub struct SemanticTest {
     pub state: State<CustomExpression, CustomExpression>,

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -8,14 +8,17 @@ use semantic_analyzer::types::PrimitiveValue;
 #[cfg(feature = "codec")]
 use serde::{Deserialize, Serialize};
 use std::cell::RefCell;
+use std::marker::PhantomData;
 use std::rc::Rc;
 
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "codec", derive(Serialize, Deserialize))]
-pub struct CustomExpression;
+pub struct CustomExpression<I: SemanticContextInstruction> {
+    _marker: PhantomData<I>,
+}
 
-impl ExtendedExpression for CustomExpression {
-    fn expression<I: SemanticContextInstruction>(
+impl<I: SemanticContextInstruction> ExtendedExpression<I> for CustomExpression<I> {
+    fn expression(
         &self,
         _state: &mut State<Self, I>,
         _block_state: &Rc<RefCell<BlockState<I>>>,
@@ -27,19 +30,27 @@ impl ExtendedExpression for CustomExpression {
     }
 }
 
-impl SemanticContextInstruction for CustomExpression {}
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "codec", derive(Serialize, Deserialize))]
+pub struct CustomExpressionInstruction;
 
-pub struct SemanticTest {
-    pub state: State<CustomExpression, CustomExpression>,
+impl SemanticContextInstruction for CustomExpressionInstruction {
+    fn instruction(&self) -> Box<Self> {
+        Box::new(Self)
+    }
 }
 
-impl Default for SemanticTest {
+pub struct SemanticTest<I: SemanticContextInstruction> {
+    pub state: State<CustomExpression<I>, I>,
+}
+
+impl Default for SemanticTest<CustomExpressionInstruction> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl SemanticTest {
+impl SemanticTest<CustomExpressionInstruction> {
     pub fn new() -> Self {
         Self {
             state: State::new(),


### PR DESCRIPTION
## Description

💾  Refactored `Extend Expression` with improved instructions generation results.
Rethinking design for `ExtendExpression` AST, and `SemanticContext` instructions for extended expressions. Previously it was different logic categories. And it was pitfalls, as it was practically difficult to generate efficient Instructions for `SemanticContext` related on AST. ⚠️ this PR is solved this to bring things in the same logic categories, and now SemanticContext for stack instructions is fully flexible for `ExtendedExpression` AST.

➡️  Added tests for `extended expressions` and `SemanticStackContext instructions` for it
➡️  Extended (README)[README.md] documentation
➡️  Refactored AST to add generic type for `ExtendedExpression` instructions
➡️  Extended clippy to new Rust requirements


