### PR TITLE
Feat: Remove String type

### DIFF
--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -30,6 +30,6 @@ jobs:
       - name: Format
         run: cargo fmt --all -- --check
       - name: Clippy no-default-features
-        run: cargo clippy --all --all-targets --no-default-features -- -D warnings
+        run: cargo +nightly clippy --all --all-targets --no-default-features -- -D warnings
       - name: Clippy
-        run: cargo clippy --all --all-targets --all-features -- -D warnings
+        run: cargo +nightly clippy --all --all-targets --all-features -- -D warnings

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -15,7 +15,7 @@ jobs:
         os:
           - ubuntu-latest
         rust:
-          - stable
+          - nightly
     
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
         os:
           - ubuntu-latest
         rust:
-          - stable
+          - nightly
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
         os:
           - ubuntu-latest
         rust:
-          - nightly
+          - stable
 
     steps:
       - uses: actions/checkout@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-analyzer"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["Evgeny Ukhanov <mrlsd@ya.ru>"]
 description = "Semantic analyzer library for compilers written in Rust for semantic analysis of programming languages AST"
 keywords = ["compiler", "semantic-analisis", "semantic-alalyzer", "compiler-design", "semantic"]

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -535,7 +535,7 @@ pub struct FunctionStatement<'a, I: SemanticContextInstruction, E: ExtendedExpre
 
 impl<'a, I: SemanticContextInstruction, E: ExtendedExpression<I>> FunctionStatement<'a, I, E> {
     #[must_use]
-    pub fn new(
+    pub const fn new(
         name: FunctionName<'a>,
         parameters: Vec<FunctionParameter<'a>>,
         result_type: Type<'a>,

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -329,7 +329,6 @@ pub enum PrimitiveTypes {
     F64,
     Bool,
     Char,
-    String,
     Ptr,
     None,
 }
@@ -349,7 +348,6 @@ impl GetName for PrimitiveTypes {
             Self::F64 => "f64".to_string(),
             Self::Bool => "bool".to_string(),
             Self::Char => "char".to_string(),
-            Self::String => "str".to_string(),
             Self::Ptr => "ptr".to_string(),
             Self::None => "()".to_string(),
         }
@@ -590,7 +588,6 @@ pub enum PrimitiveValue {
     F32(f32),
     F64(f64),
     Bool(bool),
-    String(String),
     Char(char),
     Ptr,
     None,
@@ -612,7 +609,6 @@ impl PrimitiveValue {
             Self::F64(_) => Type::Primitive(PrimitiveTypes::F64),
             Self::Char(_) => Type::Primitive(PrimitiveTypes::Char),
             Self::Bool(_) => Type::Primitive(PrimitiveTypes::Bool),
-            Self::String(_) => Type::Primitive(PrimitiveTypes::String),
             Self::Ptr => Type::Primitive(PrimitiveTypes::Ptr),
             Self::None => Type::Primitive(PrimitiveTypes::None),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #![deny(clippy::pedantic, clippy::nursery)]
-#![allow(clippy::module_name_repetitions)]
+#![allow(clippy::module_name_repetitions, clippy::doc_lazy_continuation)]
 //! # Semantic Analyzer
 //! The semantic analyzer consists of the following basic elements:
 //! - AST is an abstract syntax tree that implements a predefined set of

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -435,7 +435,6 @@ impl From<ast::PrimitiveValue> for PrimitiveValue {
             ast::PrimitiveValue::F32(v) => Self::F32(v),
             ast::PrimitiveValue::F64(v) => Self::F64(v),
             ast::PrimitiveValue::Bool(v) => Self::Bool(v),
-            ast::PrimitiveValue::String(v) => Self::String(v),
             ast::PrimitiveValue::Char(v) => Self::Char(v),
             ast::PrimitiveValue::Ptr => Self::Ptr,
             ast::PrimitiveValue::None => Self::None,

--- a/src/types/types.rs
+++ b/src/types/types.rs
@@ -89,7 +89,7 @@ impl Display for Type {
                 format!("[{:?};{:?}]", array_type.to_string(), size)
             }
         };
-        write!(f, "{str}",)
+        write!(f, "{str}")
     }
 }
 
@@ -157,7 +157,6 @@ pub enum PrimitiveTypes {
     F64,
     Bool,
     Char,
-    String,
     Ptr,
     None,
 }
@@ -177,7 +176,6 @@ impl Display for PrimitiveTypes {
             Self::F64 => "f64",
             Self::Bool => "bool",
             Self::Char => "char",
-            Self::String => "str",
             Self::Ptr => "ptr",
             Self::None => "()",
         };
@@ -200,7 +198,6 @@ impl From<ast::PrimitiveTypes> for PrimitiveTypes {
             ast::PrimitiveTypes::F64 => Self::F64,
             ast::PrimitiveTypes::Bool => Self::Bool,
             ast::PrimitiveTypes::Char => Self::Char,
-            ast::PrimitiveTypes::String => Self::String,
             ast::PrimitiveTypes::Ptr => Self::Ptr,
             ast::PrimitiveTypes::None => Self::None,
         }

--- a/tests/codec_tests.rs
+++ b/tests/codec_tests.rs
@@ -226,11 +226,6 @@ mod test {
         let to_val = serde_json::from_str(&to_json).unwrap();
         assert_eq!(pv, to_val);
 
-        let pv = ast::PrimitiveValue::String("test".to_string());
-        let to_json = serde_json::to_string(&pv).unwrap();
-        let to_val = serde_json::from_str(&to_json).unwrap();
-        assert_eq!(pv, to_val);
-
         let cl = ast::CodeLocation::new(10, 20);
         let to_json = serde_json::to_string(&cl).unwrap();
         let to_val = serde_json::from_str(&to_json).unwrap();

--- a/tests/expressions_tests.rs
+++ b/tests/expressions_tests.rs
@@ -311,27 +311,6 @@ fn expression_ast_transform_primitive_value_bool() {
 }
 
 #[test]
-fn expression_ast_transform_primitive_value_string() {
-    let val = ast::PrimitiveValue::String("str".to_string());
-    assert_eq!(
-        val.get_type(),
-        ast::Type::Primitive(ast::PrimitiveTypes::String)
-    );
-    let expr_val: PrimitiveValue = val.clone().into();
-    assert_eq!(PrimitiveValue::String("str".to_string()), expr_val);
-    assert_eq!(expr_val.to_string(), "str");
-    let expr: Expression = ast::Expression {
-        expression_value: ast::ExpressionValue::<
-            CustomExpressionInstruction,
-            CustomExpression<CustomExpressionInstruction>,
-        >::PrimitiveValue(val),
-        operation: None,
-    }
-    .into();
-    assert_eq!(expr.to_string(), "str");
-}
-
-#[test]
 fn expression_ast_transform_primitive_value_char() {
     let val = ast::PrimitiveValue::Char('a');
     assert_eq!(

--- a/tests/types_tests.rs
+++ b/tests/types_tests.rs
@@ -75,7 +75,7 @@ fn types_ast_transform() {
     };
     let ty13 = ast::StructType {
         attr_name: Ident::new("attr13"),
-        attr_type: ast::Type::Primitive(ast::PrimitiveTypes::String),
+        attr_type: ast::Type::Primitive(ast::PrimitiveTypes::U64),
     };
     let ty14 = ast::StructType {
         attr_name: Ident::new("attr14"),
@@ -322,7 +322,7 @@ fn types_declaration() {
     };
     let ty2 = ast::StructType {
         attr_name: Ident::new("attr2"),
-        attr_type: ast::Type::Primitive(ast::PrimitiveTypes::String),
+        attr_type: ast::Type::Primitive(ast::PrimitiveTypes::U8),
     };
     let type_decl2 = ast::StructTypes {
         name: Ident::new("type2"),

--- a/tests/types_tests.rs
+++ b/tests/types_tests.rs
@@ -227,11 +227,11 @@ fn types_ast_transform() {
     assert_eq!(attr12.attr_index, 11);
 
     let attr13 = type_into2.attributes.get(&("attr13".into())).unwrap();
-    assert_eq!(ty13.attr_type.name(), "str");
+    assert_eq!(ty13.attr_type.name(), "u64");
     let ty13: StructAttributeType = ty13.into();
     assert_eq!(attr13.attr_name, ty13.attr_name);
     assert_eq!(attr13.attr_type, ty13.attr_type);
-    assert_eq!(attr13.attr_type.to_string(), "str");
+    assert_eq!(attr13.attr_type.to_string(), "u64");
     assert_eq!(attr13.attr_index, 12);
 
     let attr14 = type_into2.attributes.get(&("attr14".into())).unwrap();


### PR DESCRIPTION
## Description

↪️  Implementation of #31 

### String type considerations

`PromitiveTypes` represents only the most primitive types.

As potential pitfalls for backend implementation, `String` type mostly represents a complex type. For examples:
- `sized array[char]`
- `unsized array[u8]`
- or other, including low-level LLVM representations.

✅  To avoid that collision, `String` type was removed from `PromitiveTypes`.
