### PR TITLE
Chore: Update clippy & dependencies

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,15 +40,15 @@ jobs:
         run: cargo build --all-features
       - name: Test
         run: cargo test --all-targets --all-features
-        env:
-          CARGO_INCREMENTAL: '0'
-          RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Copt-level=0 -Cllvm-args=--inline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort'
-          RUSTDOCFLAGS: '-Zprofile -Ccodegen-units=1 -Copt-level=0 -Cllvm-args=--inline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort'
-      - name: Install grcov
-        run: |
-          if [[ ! -f ~/.cargo/bin/grcov ]]; then
-            cargo install grcov          
-          fi
+#        env:
+#          CARGO_INCREMENTAL: '0'
+#          RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Copt-level=0 -Cllvm-args=--inline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort'
+#          RUSTDOCFLAGS: '-Zprofile -Ccodegen-units=1 -Copt-level=0 -Cllvm-args=--inline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort'
+#      - name: Install grcov
+#        run: |
+#          if [[ ! -f ~/.cargo/bin/grcov ]]; then
+#            cargo install grcov
+#          fi
       - name: Save cache
         uses: actions/cache/save@v3
         with:
@@ -58,17 +58,16 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
           key: ${{ runner.os }}-cargo
-      - name: Run grcov
-        run: |
-          mkdir ./target/debug/coverage/
-          grcov . -s . -b ./target/debug/ -o ./target/debug/coverage/  --ignore-not-existing --excl-line="grcov-excl-line|#\\[derive\\(|//!|///" --excl-start="grcov-excl-start"  --excl-stop="grcov-excl-end" --ignore="*.cargo/*" --ignore="src/lib.rs" --ignore="tests/*"
-      - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        with:
-          directory: ./target/debug/coverage/
-          files: ./target/debug/coverage/lcov
-          verbose: true
-          fail_ci_if_error: true
-
+#      - name: Run grcov
+#        run: |
+#          mkdir ./target/debug/coverage/
+#          grcov . -s . -b ./target/debug/ -o ./target/debug/coverage/  --ignore-not-existing --excl-line="grcov-excl-line|#\\[derive\\(|//!|///" --excl-start="grcov-excl-start"  --excl-stop="grcov-excl-end" --ignore="*.cargo/*" --ignore="src/lib.rs" --ignore="tests/*"
+#      - name: Upload coverage reports to Codecov
+#        uses: codecov/codecov-action@v3
+#        env:
+#          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+#        with:
+#          directory: ./target/debug/coverage/
+#          files: ./target/debug/coverage/lcov
+#          verbose: true
+#          fail_ci_if_error: true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-analyzer"
-version = "0.4.5"
+version = "0.4.6"
 authors = ["Evgeny Ukhanov <mrlsd@ya.ru>"]
 description = "Semantic analyzer library for compilers written in Rust for semantic analysis of programming languages AST"
 keywords = ["compiler", "semantic-analisis", "semantic-alalyzer", "compiler-design", "semantic"]
@@ -14,7 +14,7 @@ repository = "https://github.com/mrLSD/semantic-analyzer-rs"
 doctest = false
 
 [dependencies]
-nom_locate = "4.2"
+nom_locate = "5.0"
 serde = { version = "1", features = ["derive"], optional = true }
 
 [dev-dependencies]

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -44,7 +44,7 @@ impl<'a> Ident<'a> {
     }
 }
 
-impl<'a> std::fmt::Display for Ident<'a> {
+impl std::fmt::Display for Ident<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.fragment())
     }
@@ -58,7 +58,7 @@ impl<'a> From<&'a str> for Ident<'a> {
 
 /// Ident Serializer
 #[cfg(feature = "codec")]
-impl<'a> Serialize for Ident<'a> {
+impl Serialize for Ident<'_> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -227,7 +227,7 @@ impl GetLocation for FunctionName<'_> {
     }
 }
 
-impl<'a> std::fmt::Display for FunctionName<'a> {
+impl std::fmt::Display for FunctionName<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.0.fragment())
     }
@@ -406,7 +406,7 @@ impl GetLocation for StructTypes<'_> {
     }
 }
 
-impl<'a> GetName for StructTypes<'a> {
+impl GetName for StructTypes<'_> {
     fn name(&self) -> String {
         (*self.name.fragment()).to_string()
     }
@@ -430,7 +430,7 @@ pub enum Type<'a> {
     Array(Box<Self>, u32),
 }
 
-impl<'a> GetName for Type<'a> {
+impl GetName for Type<'_> {
     fn name(&self) -> String {
         match self {
             Self::Primitive(primitive) => primitive.name(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,9 @@
 #![deny(clippy::pedantic, clippy::nursery, clippy::as_conversions)]
-#![allow(clippy::module_name_repetitions, clippy::doc_lazy_continuation)]
+#![allow(
+    clippy::module_name_repetitions,
+    clippy::doc_lazy_continuation,
+    clippy::too_long_first_doc_paragraph
+)]
 //! # Semantic Analyzer
 //! The semantic analyzer consists of the following basic elements:
 //! - AST is an abstract syntax tree that implements a predefined set of

--- a/src/semantic.rs
+++ b/src/semantic.rs
@@ -748,7 +748,7 @@ where
                         if_body_state.borrow_mut().jump_function_return(res);
                         if_body_state.borrow_mut().set_return();
                         return_is_called = true;
-                    };
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Description

🚀  Updated and fixed `clippy` warnings and bumped dependencies to new version
⚠️ Remove `codecov` upload. As at the moment after Rust compuler removed `-Zprofile` option, it's impossible correctly to use `grcov`: https://github.com/mozilla/grcov/issues/1240