### PR TITLE
Feat: update rust edtion to 2024 and fix new clippy rules issues

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,15 +40,15 @@ jobs:
         run: cargo build --all-features
       - name: Test
         run: cargo test --all-targets --all-features
-        env:
-          CARGO_INCREMENTAL: '0'
-          RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Copt-level=0 -Cllvm-args=--inline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort'
-          RUSTDOCFLAGS: '-Zprofile -Ccodegen-units=1 -Copt-level=0 -Cllvm-args=--inline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort'
-      - name: Install grcov
-        run: |
-          if [[ ! -f ~/.cargo/bin/grcov ]]; then
-            cargo install grcov          
-          fi
+#        env:
+#          CARGO_INCREMENTAL: '0'
+#          RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Copt-level=0 -Cllvm-args=--inline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort'
+#          RUSTDOCFLAGS: '-Zprofile -Ccodegen-units=1 -Copt-level=0 -Cllvm-args=--inline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort'
+#      - name: Install grcov
+#        run: |
+#          if [[ ! -f ~/.cargo/bin/grcov ]]; then
+#            cargo install grcov
+#          fi
       - name: Save cache
         uses: actions/cache/save@v3
         with:
@@ -58,17 +58,16 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
           key: ${{ runner.os }}-cargo
-      - name: Run grcov
-        run: |
-          mkdir ./target/debug/coverage/
-          grcov . -s . -b ./target/debug/ -o ./target/debug/coverage/  --ignore-not-existing --excl-line="grcov-excl-line|#\\[derive\\(|//!|///" --excl-start="grcov-excl-start"  --excl-stop="grcov-excl-end" --ignore="*.cargo/*" --ignore="src/lib.rs" --ignore="tests/*"
-      - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        with:
-          directory: ./target/debug/coverage/
-          files: ./target/debug/coverage/lcov
-          verbose: true
-          fail_ci_if_error: true
-
+#      - name: Run grcov
+#        run: |
+#          mkdir ./target/debug/coverage/
+#          grcov . -s . -b ./target/debug/ -o ./target/debug/coverage/  --ignore-not-existing --excl-line="grcov-excl-line|#\\[derive\\(|//!|///" --excl-start="grcov-excl-start"  --excl-stop="grcov-excl-end" --ignore="*.cargo/*" --ignore="src/lib.rs" --ignore="tests/*"
+#      - name: Upload coverage reports to Codecov
+#        uses: codecov/codecov-action@v3
+#        env:
+#          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+#        with:
+#          directory: ./target/debug/coverage/
+#          files: ./target/debug/coverage/lcov
+#          verbose: true
+#          fail_ci_if_error: true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-analyzer"
-version = "0.4.5"
+version = "0.4.6"
 authors = ["Evgeny Ukhanov <mrlsd@ya.ru>"]
 description = "Semantic analyzer library for compilers written in Rust for semantic analysis of programming languages AST"
 keywords = ["compiler", "semantic-analisis", "semantic-alalyzer", "compiler-design", "semantic"]
@@ -14,7 +14,7 @@ repository = "https://github.com/mrLSD/semantic-analyzer-rs"
 doctest = false
 
 [dependencies]
-nom_locate = "4.2"
+nom_locate = "5.0"
 serde = { version = "1", features = ["derive"], optional = true }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ as_conversions = "deny"
 module_name_repetitions = "allow"
 doc_lazy_continuation = "allow"
 too_long_first_doc_paragraph = "allow"
+too_many_lines = "allow"
 
 [lib]
 doctest = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,24 @@
 [package]
 name = "semantic-analyzer"
-version = "0.4.6"
+version = "0.4.7"
 authors = ["Evgeny Ukhanov <mrlsd@ya.ru>"]
 description = "Semantic analyzer library for compilers written in Rust for semantic analysis of programming languages AST"
 keywords = ["compiler", "semantic-analisis", "semantic-alalyzer", "compiler-design", "semantic"]
 categories = ["compilers", "development-tools", "development-tools::build-utils"]
 license = "MIT"
-edition = "2021"
+edition = "2024"
 homepage = "https://github.com/mrLSD/semantic-analyzer-rs"
 repository = "https://github.com/mrLSD/semantic-analyzer-rs"
+# Edition 2024 requires Rust 1.85.0 or later
+rust-version = "1.85.0"
+
+[lints.clippy]
+pedantic = { level = "deny", priority = -1 }
+nursery = { level = "deny", priority = -1 }
+as_conversions = "deny"
+module_name_repetitions = "allow"
+doc_lazy_continuation = "allow"
+too_long_first_doc_paragraph = "allow"
 
 [lib]
 doctest = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,8 @@ license = "MIT"
 edition = "2024"
 homepage = "https://github.com/mrLSD/semantic-analyzer-rs"
 repository = "https://github.com/mrLSD/semantic-analyzer-rs"
-# Edition 2024 requires Rust 1.85.0 or later
-rust-version = "1.85.0"
+# let-chains require Rust 1.88.0
+rust-version = "1.88.0"
 
 [lints.clippy]
 pedantic = { level = "deny", priority = -1 }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -44,7 +44,7 @@ impl<'a> Ident<'a> {
     }
 }
 
-impl<'a> std::fmt::Display for Ident<'a> {
+impl std::fmt::Display for Ident<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.fragment())
     }
@@ -58,7 +58,7 @@ impl<'a> From<&'a str> for Ident<'a> {
 
 /// Ident Serializer
 #[cfg(feature = "codec")]
-impl<'a> Serialize for Ident<'a> {
+impl Serialize for Ident<'_> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -227,7 +227,7 @@ impl GetLocation for FunctionName<'_> {
     }
 }
 
-impl<'a> std::fmt::Display for FunctionName<'a> {
+impl std::fmt::Display for FunctionName<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.0.fragment())
     }
@@ -406,7 +406,7 @@ impl GetLocation for StructTypes<'_> {
     }
 }
 
-impl<'a> GetName for StructTypes<'a> {
+impl GetName for StructTypes<'_> {
     fn name(&self) -> String {
         (*self.name.fragment()).to_string()
     }
@@ -430,7 +430,7 @@ pub enum Type<'a> {
     Array(Box<Self>, u32),
 }
 
-impl<'a> GetName for Type<'a> {
+impl GetName for Type<'_> {
     fn name(&self) -> String {
         match self {
             Self::Primitive(primitive) => primitive.name(),

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -7,9 +7,9 @@ use crate::types::semantic::{ExtendedExpression, SemanticContextInstruction};
 use nom_locate::LocatedSpan;
 #[cfg(feature = "codec")]
 use serde::{
+    Deserialize, Serialize,
     de::{self, Deserializer, MapAccess, Visitor},
     ser::{SerializeStruct, Serializer},
-    Deserialize, Serialize,
 };
 use std::convert::Infallible;
 use std::marker::PhantomData;
@@ -471,7 +471,7 @@ pub struct ConstantExpression<'a> {
     #[cfg_attr(feature = "codec", serde(borrow))]
     pub value: ConstantValue<'a>,
     /// Constant expression optional expression operation with other constant expression declarations.
-    pub operation: Option<(ExpressionOperations, Box<ConstantExpression<'a>>)>,
+    pub operation: Option<(ExpressionOperations, Box<Self>)>,
 }
 
 /// `Constant` constant declaration element of AST.
@@ -711,7 +711,7 @@ pub struct Expression<'a, I: SemanticContextInstruction, E: ExtendedExpression<I
     #[cfg_attr(feature = "codec", serde(borrow))]
     pub expression_value: ExpressionValue<'a, I, E>,
     /// Optional expression operation with other expression value
-    pub operation: Option<(ExpressionOperations, Box<Expression<'a, I, E>>)>,
+    pub operation: Option<(ExpressionOperations, Box<Self>)>,
 }
 
 impl<I: SemanticContextInstruction, E: ExtendedExpression<I>> GetLocation for Expression<'_, I, E> {
@@ -860,7 +860,7 @@ pub struct ExpressionLogicCondition<'a, I: SemanticContextInstruction, E: Extend
     #[cfg_attr(feature = "codec", serde(borrow))]
     pub left: ExpressionCondition<'a, I, E>,
     /// Optional right side contain logic operation to other `ExpressionLogicCondition`
-    pub right: Option<(LogicCondition, Box<ExpressionLogicCondition<'a, I, E>>)>,
+    pub right: Option<(LogicCondition, Box<Self>)>,
 }
 
 /// `IfCondition` if-condition control flow element of AST.
@@ -898,7 +898,7 @@ pub struct IfStatement<'a, I: SemanticContextInstruction, E: ExtendedExpression<
     /// If-else-body statement - body of else-condition success
     pub else_statement: Option<IfBodyStatements<'a, I, E>>,
     /// Else-if-body statement - body of else-if-condition success
-    pub else_if_statement: Option<Box<IfStatement<'a, I, E>>>,
+    pub else_if_statement: Option<Box<Self>>,
 }
 
 impl<I: SemanticContextInstruction, E: ExtendedExpression<I>> GetLocation
@@ -999,7 +999,7 @@ pub enum LoopBodyStatement<'a, I: SemanticContextInstruction, E: ExtendedExpress
     Binding(Binding<'a, I, E>),
     FunctionCall(FunctionCall<'a, I, E>),
     If(IfStatement<'a, I, E>),
-    Loop(Vec<LoopBodyStatement<'a, I, E>>),
+    Loop(Vec<Self>),
     Return(Expression<'a, I, E>),
     Break,
     Continue,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,9 @@
 #![deny(clippy::pedantic, clippy::nursery, clippy::as_conversions)]
-#![allow(clippy::module_name_repetitions, clippy::doc_lazy_continuation)]
+#![allow(
+    clippy::module_name_repetitions,
+    clippy::doc_lazy_continuation,
+    clippy::too_long_first_doc_paragraph
+)]
 //! # Semantic Analyzer
 //! The semantic analyzer consists of the following basic elements:
 //! - AST is an abstract syntax tree that implements a predefined set of

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,3 @@
-#![deny(clippy::pedantic, clippy::nursery, clippy::as_conversions)]
-#![allow(
-    clippy::module_name_repetitions,
-    clippy::doc_lazy_continuation,
-    clippy::too_long_first_doc_paragraph
-)]
 //! # Semantic Analyzer
 //! The semantic analyzer consists of the following basic elements:
 //! - AST is an abstract syntax tree that implements a predefined set of

--- a/src/semantic.rs
+++ b/src/semantic.rs
@@ -748,7 +748,7 @@ where
                         if_body_state.borrow_mut().jump_function_return(res);
                         if_body_state.borrow_mut().set_return();
                         return_is_called = true;
-                    };
+                    }
                 }
             }
         }

--- a/src/semantic.rs
+++ b/src/semantic.rs
@@ -952,7 +952,7 @@ where
             .borrow_mut()
             .get_and_set_next_label(&"if_else".to_string().into());
         // Set if-end label from previous context
-        let label_if_end = label_end.clone().unwrap_or_else(|| {
+        let label_if_end = label_end.as_ref().cloned().unwrap_or_else(|| {
             if_body_state
                 .borrow_mut()
                 .get_and_set_next_label(&"if_end".to_string().into())

--- a/src/semantic.rs
+++ b/src/semantic.rs
@@ -21,8 +21,8 @@ use crate::types::semantic::{
 };
 use crate::types::types::{Type, TypeName};
 use crate::types::{
-    error, Binding, Constant, ConstantName, Function, FunctionCall, FunctionName,
-    FunctionParameter, FunctionStatement, InnerValueName, LabelName, LetBinding, Value,
+    Binding, Constant, ConstantName, Function, FunctionCall, FunctionName, FunctionParameter,
+    FunctionStatement, InnerValueName, LabelName, LetBinding, Value, error,
 };
 #[cfg(feature = "codec")]
 use serde::{Deserialize, Serialize};
@@ -470,15 +470,15 @@ where
         };
         let let_data: LetBinding = data.clone().into();
 
-        if let Some(ty) = &let_data.value_type {
-            if &expr_result.expr_type != ty {
-                self.add_error(error::StateErrorResult::new(
-                    error::StateErrorKind::WrongLetType,
-                    let_data.to_string(),
-                    data.location(),
-                ));
-                return;
-            }
+        if let Some(ty) = &let_data.value_type
+            && &expr_result.expr_type != ty
+        {
+            self.add_error(error::StateErrorResult::new(
+                error::StateErrorKind::WrongLetType,
+                let_data.to_string(),
+                data.location(),
+            ));
+            return;
         }
         let let_ty = expr_result.expr_type.clone();
 
@@ -952,14 +952,11 @@ where
             .borrow_mut()
             .get_and_set_next_label(&"if_else".to_string().into());
         // Set if-end label from previous context
-        let label_if_end = label_end.clone().map_or_else(
-            || {
-                if_body_state
-                    .borrow_mut()
-                    .get_and_set_next_label(&"if_end".to_string().into())
-            },
-            |label| label,
-        );
+        let label_if_end = label_end.clone().unwrap_or_else(|| {
+            if_body_state
+                .borrow_mut()
+                .get_and_set_next_label(&"if_end".to_string().into())
+        });
         // To set if-end as single return point check is it previously set
         let is_set_label_if_end = label_end.is_some();
         let is_else = data.else_statement.is_some() || data.else_if_statement.is_some();

--- a/src/semantic.rs
+++ b/src/semantic.rs
@@ -952,7 +952,7 @@ where
             .borrow_mut()
             .get_and_set_next_label(&"if_else".to_string().into());
         // Set if-end label from previous context
-        let label_if_end = label_end.as_ref().cloned().unwrap_or_else(|| {
+        let label_if_end = label_end.clone().unwrap_or_else(|| {
             if_body_state
                 .borrow_mut()
                 .get_and_set_next_label(&"if_end".to_string().into())

--- a/src/semantic.rs
+++ b/src/semantic.rs
@@ -1225,7 +1225,6 @@ where
     /// `OP(lhs, rhs)`
     /// Left-value contains optional Expression result for left side
     /// of expression.
-    #[allow(clippy::too_many_lines)]
     pub fn expression_operation(
         &mut self,
         left_value: Option<&ExpressionResult>,

--- a/src/types/block_state.rs
+++ b/src/types/block_state.rs
@@ -50,7 +50,7 @@ pub struct BlockState<I: SemanticContextInstruction> {
             deserialize_with = "rc_serializer::deserialize_option"
         )
     )]
-    pub parent: Option<Rc<RefCell<BlockState<I>>>>,
+    pub parent: Option<Rc<RefCell<Self>>>,
     /// children states
     #[cfg_attr(
         feature = "codec",
@@ -59,7 +59,7 @@ pub struct BlockState<I: SemanticContextInstruction> {
             deserialize_with = "rc_serializer::deserialize_vec"
         )
     )]
-    pub children: Vec<Rc<RefCell<BlockState<I>>>>,
+    pub children: Vec<Rc<RefCell<Self>>>,
     /// Semantic stack context for Block state
     context: SemanticStack<I>,
 }
@@ -440,7 +440,7 @@ impl<I: SemanticContextInstruction> ExtendedSemanticContext<I> for BlockState<I>
 #[cfg(feature = "codec")]
 pub mod rc_serializer {
     use super::{Rc, RefCell};
-    use serde::{ser::SerializeSeq, Deserialize, Deserializer, Serialize, Serializer};
+    use serde::{Deserialize, Deserializer, Serialize, Serializer, ser::SerializeSeq};
 
     /// Serializer for `Rc<RefCell<T>`.
     #[allow(clippy::missing_errors_doc)]

--- a/src/types/condition.rs
+++ b/src/types/condition.rs
@@ -92,7 +92,7 @@ pub struct ExpressionLogicCondition {
     /// Left expression condition
     pub left: ExpressionCondition,
     /// Optional right expression condition with logic condition
-    pub right: Option<(LogicCondition, Box<ExpressionLogicCondition>)>,
+    pub right: Option<(LogicCondition, Box<Self>)>,
 }
 
 impl<I: SemanticContextInstruction, E: ExtendedExpression<I>>
@@ -145,7 +145,7 @@ pub struct IfStatement {
     /// Basic else-body, if if-condition is false
     pub else_statement: Option<IfBodyStatements>,
     /// Basic else-if-body
-    pub else_if_statement: Option<Box<IfStatement>>,
+    pub else_if_statement: Option<Box<Self>>,
 }
 
 impl<I: SemanticContextInstruction, E: ExtendedExpression<I>> From<ast::IfStatement<'_, I, E>>
@@ -202,7 +202,7 @@ pub enum LoopBodyStatement {
     Binding(Binding),
     FunctionCall(FunctionCall),
     If(IfStatement),
-    Loop(Vec<LoopBodyStatement>),
+    Loop(Vec<Self>),
     Return(Expression),
     Break,
     Continue,

--- a/src/types/expression.rs
+++ b/src/types/expression.rs
@@ -185,7 +185,7 @@ pub struct Expression {
     /// Expression value
     pub expression_value: ExpressionValue,
     /// Optional expression operation under other `Expression`
-    pub operation: Option<(ExpressionOperations, Box<Expression>)>,
+    pub operation: Option<(ExpressionOperations, Box<Self>)>,
 }
 
 impl Display for Expression {

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -181,7 +181,7 @@ pub struct ConstantExpression {
     /// Constant value for expression operation
     pub value: ConstantValue,
     /// Optional expression operation and next constant expression entry point
-    pub operation: Option<(ExpressionOperations, Box<ConstantExpression>)>,
+    pub operation: Option<(ExpressionOperations, Box<Self>)>,
 }
 
 impl From<ast::ConstantExpression<'_>> for ConstantExpression {

--- a/tests/binding_tests.rs
+++ b/tests/binding_tests.rs
@@ -29,7 +29,7 @@ fn binding_transform() {
     assert_eq!(binding_ast.clone().name(), "x");
 
     let binding: Binding = binding_ast.clone().into();
-    assert_eq!(binding.clone().to_string(), "x");
+    assert_eq!(binding.to_string(), "x");
     assert_eq!(binding.value, Box::new(expr_ast.into()));
     // For grcov
     let _ = format!("{:?}", binding_ast.clone());
@@ -53,7 +53,7 @@ fn binding_wrong_expression() {
     t.state.binding(&binding, &block_state);
     assert!(t.check_errors_len(1), "Errors: {:?}", t.state.errors.len());
     assert!(
-        t.check_error(StateErrorKind::ValueNotFound),
+        t.check_error(&StateErrorKind::ValueNotFound),
         "Errors: {:?}",
         t.state.errors[0]
     );
@@ -77,7 +77,7 @@ fn binding_value_not_exist() {
     t.state.binding(&binding, &block_state);
     assert!(t.check_errors_len(1), "Errors: {:?}", t.state.errors.len());
     assert!(
-        t.check_error(StateErrorKind::ValueNotFound),
+        t.check_error(&StateErrorKind::ValueNotFound),
         "Errors: {:?}",
         t.state.errors[0]
     );
@@ -135,7 +135,7 @@ fn binding_value_not_mutable() {
     t.state.binding(&binding, &block_state);
     assert!(t.check_errors_len(1), "Errors: {:?}", t.state.errors.len());
     assert!(
-        t.check_error(StateErrorKind::ValueIsNotMutable),
+        t.check_error(&StateErrorKind::ValueIsNotMutable),
         "Errors: {:?}",
         t.state.errors[0]
     );
@@ -169,7 +169,7 @@ fn binding_value_found() {
         malloc: false,
     };
 
-    let state = block_state.borrow().get_context().clone().get();
+    let state = block_state.borrow().get_context().get();
     assert_eq!(state.len(), 1);
     assert_eq!(
         state[0],
@@ -199,7 +199,7 @@ fn binding_value_found() {
     };
     t.state.binding(&binding, &block_state);
     assert!(t.is_empty_error());
-    let state = block_state.borrow().get_context().clone().get();
+    let state = block_state.borrow().get_context().get();
     assert_eq!(state.len(), 2);
     assert_eq!(
         state[0],
@@ -214,7 +214,7 @@ fn binding_value_found() {
     assert_eq!(
         state[1],
         SemanticStackContext::Binding {
-            val: val.clone(),
+            val,
             expr_result: ExpressionResult {
                 expr_type: Type::Primitive(PrimitiveTypes::U64),
                 expr_value: ExpressionResultValue::PrimitiveValue(PrimitiveValue::U64(100)),

--- a/tests/const_tests.rs
+++ b/tests/const_tests.rs
@@ -3,8 +3,8 @@ use semantic_analyzer::ast::{self, CodeLocation, GetLocation, GetName, Ident};
 use semantic_analyzer::types::error::StateErrorKind;
 use semantic_analyzer::types::expression::ExpressionOperations;
 use semantic_analyzer::types::{
-    semantic::SemanticStackContext, Constant, ConstantExpression, ConstantName, ConstantValue,
-    PrimitiveValue,
+    Constant, ConstantExpression, ConstantName, ConstantValue, PrimitiveValue,
+    semantic::SemanticStackContext,
 };
 
 mod utils;
@@ -163,11 +163,12 @@ fn const_declaration_with_operations() {
         "Errors: {:?}",
         t.state.errors[0]
     );
-    assert!(!t
-        .state
-        .global
-        .constants
-        .contains_key(&const_name1.clone().into()));
+    assert!(
+        !t.state
+            .global
+            .constants
+            .contains_key(&const_name1.clone().into())
+    );
     t.clean_errors();
 
     // constant2

--- a/tests/const_tests.rs
+++ b/tests/const_tests.rs
@@ -81,11 +81,11 @@ fn const_expr_ast_transform() {
 
     let expr_op: ExpressionOperations = ast::ExpressionOperations::Eq.into();
     let c_val2: ConstantValue = cnt_expr_prev.value.into();
-    let cnt_expr_op = cnt_expr.operation.clone().unwrap();
+    let cnt_expr_op = cnt_expr.operation.unwrap();
     assert_eq!(cnt_expr_op.0, expr_op);
     assert_eq!(cnt_expr_op.1.value, c_val2);
 
-    let cnt_expr_op2 = cnt_expr_op.clone().1.operation.unwrap();
+    let cnt_expr_op2 = cnt_expr_op.1.operation.unwrap();
     let c_val3: ConstantValue = cnt_expr_prev2.value.into();
     assert_eq!(cnt_expr_op2.0, expr_op);
     assert_eq!(cnt_expr_op2.1.value, c_val3);
@@ -122,7 +122,7 @@ fn const_declaration() {
     t.state.constant(&const_statement);
     assert!(t.check_errors_len(1), "Errors: {:?}", t.state.errors.len());
     assert!(
-        t.check_error(StateErrorKind::ConstantAlreadyExist),
+        t.check_error(&StateErrorKind::ConstantAlreadyExist),
         "Errors: {:?}",
         t.state.errors[0]
     );
@@ -159,7 +159,7 @@ fn const_declaration_with_operations() {
     t.state.constant(&const_statement);
     assert!(t.check_errors_len(1), "Errors: {:?}", t.state.errors.len());
     assert!(
-        t.check_error(StateErrorKind::ConstantNotFound),
+        t.check_error(&StateErrorKind::ConstantNotFound),
         "Errors: {:?}",
         t.state.errors[0]
     );

--- a/tests/errors_tests.rs
+++ b/tests/errors_tests.rs
@@ -21,6 +21,6 @@ fn error_trace() {
         err_res2.trace_state(),
         "[ReturnNotFound] for value \"test2\" at: 2:2"
     );
-    let errs = [err_res, err_res2.clone()];
+    let errs = [err_res, err_res2];
     assert_eq!(errs.len(), 2);
 }

--- a/tests/expressions_tests.rs
+++ b/tests/expressions_tests.rs
@@ -32,12 +32,12 @@ fn set_result_type(
     let left_val = if reg_left {
         ExpressionResultValue::Register(left)
     } else {
-        ExpressionResultValue::PrimitiveValue(PrimitiveValue::U16(left as u16))
+        ExpressionResultValue::PrimitiveValue(PrimitiveValue::U16(u16::try_from(left).unwrap()))
     };
     let right_val = if reg_right {
         ExpressionResultValue::Register(right)
     } else {
-        ExpressionResultValue::PrimitiveValue(PrimitiveValue::U16(right as u16))
+        ExpressionResultValue::PrimitiveValue(PrimitiveValue::U16(u16::try_from(right).unwrap()))
     };
     SemanticStackContext::ExpressionOperation {
         operation: op,
@@ -415,7 +415,7 @@ fn expression_value_name_not_found() {
     let res = t.state.expression(&expr, &block_state);
     assert!(res.is_none());
     assert!(
-        t.check_error(StateErrorKind::ValueNotFound),
+        t.check_error(&StateErrorKind::ValueNotFound),
         "Errors: {:?}",
         t.state.errors[0]
     );
@@ -589,7 +589,7 @@ fn expression_struct_value_not_found() {
     assert!(res.is_none());
     assert!(t.check_errors_len(1), "Errors: {:?}", t.state.errors.len());
     assert!(
-        t.check_error(StateErrorKind::ValueNotFound),
+        t.check_error(&StateErrorKind::ValueNotFound),
         "Errors: {:?}",
         t.state.errors[0]
     );
@@ -619,7 +619,7 @@ fn expression_struct_value_wrong_struct_type() {
     assert!(res.is_none());
     assert!(t.check_errors_len(1), "Errors: {:?}", t.state.errors.len());
     assert!(
-        t.check_error(StateErrorKind::ValueNotStruct),
+        t.check_error(&StateErrorKind::ValueNotStruct),
         "Errors: {:?}",
         t.state.errors[0]
     );
@@ -657,7 +657,7 @@ fn expression_struct_value_type_not_found() {
     assert!(res.is_none());
     assert!(t.check_errors_len(1), "Errors: {:?}", t.state.errors.len());
     assert!(
-        t.check_error(StateErrorKind::TypeNotFound),
+        t.check_error(&StateErrorKind::TypeNotFound),
         "Errors: {:?}",
         t.state.errors[0]
     );
@@ -706,7 +706,7 @@ fn expression_struct_value_wrong_expression_type() {
     assert!(res.is_none());
     assert!(t.check_errors_len(1), "Errors: {:?}", t.state.errors.len());
     assert!(
-        t.check_error(StateErrorKind::WrongExpressionType),
+        t.check_error(&StateErrorKind::WrongExpressionType),
         "Errors: {:?}",
         t.state.errors[0]
     );
@@ -755,7 +755,7 @@ fn expression_struct_value_wrong_struct_attribute() {
     assert!(res.is_none());
     assert!(t.check_errors_len(1), "Errors: {:?}", t.state.errors.len());
     assert!(
-        t.check_error(StateErrorKind::ValueNotStructField),
+        t.check_error(&StateErrorKind::ValueNotStructField),
         "Errors: {:?}",
         t.state.errors[0]
     );
@@ -846,7 +846,7 @@ fn expression_func_call() {
     assert!(res.is_none());
     assert!(t.check_errors_len(1), "Errors: {:?}", t.state.errors.len());
     assert!(
-        t.check_error(StateErrorKind::FunctionNotFound),
+        t.check_error(&StateErrorKind::FunctionNotFound),
         "Errors: {:?}",
         t.state.errors[0]
     );
@@ -967,7 +967,7 @@ fn expression_operation_wrong_type() {
     let res = t.state.expression(&expr, &block_state);
     assert!(t.check_errors_len(1), "Errors: {:?}", t.state.errors.len());
     assert!(
-        t.check_error(StateErrorKind::WrongExpressionType),
+        t.check_error(&StateErrorKind::WrongExpressionType),
         "Errors: {:?}",
         t.state.errors[0]
     );

--- a/tests/expressions_tests.rs
+++ b/tests/expressions_tests.rs
@@ -32,12 +32,16 @@ fn set_result_type(
     let left_val = if reg_left {
         ExpressionResultValue::Register(left)
     } else {
-        ExpressionResultValue::PrimitiveValue(PrimitiveValue::U16(u16::try_from(left).unwrap()))
+        ExpressionResultValue::PrimitiveValue(PrimitiveValue::U16(
+            u16::try_from(left).expect("fits in u1"),
+        ))
     };
     let right_val = if reg_right {
         ExpressionResultValue::Register(right)
     } else {
-        ExpressionResultValue::PrimitiveValue(PrimitiveValue::U16(u16::try_from(right).unwrap()))
+        ExpressionResultValue::PrimitiveValue(PrimitiveValue::U16(
+            u16::try_from(right).expect("fits in u1"),
+        ))
     };
     SemanticStackContext::ExpressionOperation {
         operation: op,

--- a/tests/expressions_tests.rs
+++ b/tests/expressions_tests.rs
@@ -8,12 +8,12 @@ use semantic_analyzer::types::expression::{
 };
 use semantic_analyzer::types::semantic::{ExtendedSemanticContext, SemanticStackContext};
 use semantic_analyzer::types::{
+    Constant, ConstantExpression, ConstantName, ConstantValue, Function, PrimitiveValue, Value,
+    ValueName,
     block_state::BlockState,
     error::StateErrorKind,
     expression::ExpressionResultValue,
     types::{PrimitiveTypes, Type},
-    Constant, ConstantExpression, ConstantName, ConstantValue, Function, PrimitiveValue, Value,
-    ValueName,
 };
 use std::cell::RefCell;
 use std::marker::PhantomData;

--- a/tests/expressions_tests.rs
+++ b/tests/expressions_tests.rs
@@ -419,7 +419,7 @@ fn expression_value_name_not_found() {
         "Errors: {:?}",
         t.state.errors[0]
     );
-    let state = block_state.borrow().get_context().clone().get();
+    let state = block_state.borrow().get_context().get();
     assert!(state.is_empty());
     assert!(t.check_errors_len(1), "Errors: {:?}", t.state.errors.len());
 }
@@ -448,7 +448,7 @@ fn expression_value_name_exists() {
     let res = t.state.expression(&expr, &block_state).unwrap();
     assert_eq!(res.expr_value, ExpressionResultValue::Register(1));
     assert_eq!(res.expr_type, ty);
-    let state = block_state.borrow().get_context().clone().get();
+    let state = block_state.borrow().get_context().get();
     assert_eq!(state.len(), 1);
     assert_eq!(
         state[0],
@@ -484,7 +484,7 @@ fn expression_const_exists() {
     let res = t.state.expression(&expr, &block_state).unwrap();
     assert_eq!(res.expr_value, ExpressionResultValue::Register(1));
     assert_eq!(res.expr_type, ty);
-    let state = block_state.borrow().get_context().clone().get();
+    let state = block_state.borrow().get_context().get();
     assert_eq!(state.len(), 1);
     assert_eq!(
         state[0],
@@ -510,7 +510,7 @@ fn expression_primitive_value() {
         ExpressionResultValue::PrimitiveValue(PrimitiveValue::I32(10))
     );
     assert_eq!(res.expr_type, Type::Primitive(PrimitiveTypes::I32));
-    let state = block_state.borrow().get_context().clone().get();
+    let state = block_state.borrow().get_context().get();
     assert!(state.is_empty());
     assert!(t.is_empty_error());
 }
@@ -614,10 +614,7 @@ fn expression_struct_value_wrong_struct_type() {
         alloca: false,
         malloc: false,
     };
-    block_state
-        .borrow_mut()
-        .values
-        .insert("x".into(), val.clone());
+    block_state.borrow_mut().values.insert("x".into(), val);
     let res = t.state.expression(&expr, &block_state);
     assert!(res.is_none());
     assert!(t.check_errors_len(1), "Errors: {:?}", t.state.errors.len());
@@ -655,10 +652,7 @@ fn expression_struct_value_type_not_found() {
         alloca: false,
         malloc: false,
     };
-    block_state
-        .borrow_mut()
-        .values
-        .insert("x".into(), val.clone());
+    block_state.borrow_mut().values.insert("x".into(), val);
     let res = t.state.expression(&expr, &block_state);
     assert!(res.is_none());
     assert!(t.check_errors_len(1), "Errors: {:?}", t.state.errors.len());
@@ -696,10 +690,7 @@ fn expression_struct_value_wrong_expression_type() {
         alloca: false,
         malloc: false,
     };
-    block_state
-        .borrow_mut()
-        .values
-        .insert("x".into(), val.clone());
+    block_state.borrow_mut().values.insert("x".into(), val);
 
     let s_attr = ast::StructType {
         attr_name: Ident::new("attr1"),
@@ -748,10 +739,7 @@ fn expression_struct_value_wrong_struct_attribute() {
         alloca: false,
         malloc: false,
     };
-    block_state
-        .borrow_mut()
-        .values
-        .insert("x".into(), val.clone());
+    block_state.borrow_mut().values.insert("x".into(), val);
 
     let s_attr = ast::StructType {
         attr_name: Ident::new("attr1"),
@@ -824,7 +812,7 @@ fn expression_struct_value() {
     assert!(t.is_empty_error());
     assert_eq!(res.expr_value, ExpressionResultValue::Register(2));
     assert_eq!(res.expr_type, Type::Primitive(PrimitiveTypes::Bool));
-    let state = block_state.borrow().get_context().clone().get();
+    let state = block_state.borrow().get_context().get();
     assert_eq!(state.len(), 1);
     assert_eq!(
         state[0],
@@ -883,7 +871,7 @@ fn expression_func_call() {
             expr_type: Type::Primitive(PrimitiveTypes::Ptr),
         }
     );
-    let state = block_state.borrow().get_context().clone().get();
+    let state = block_state.borrow().get_context().get();
     assert_eq!(state.len(), 1);
     assert_eq!(
         state[0],
@@ -920,7 +908,7 @@ fn expression_sub_expression() {
             expr_type: Type::Primitive(PrimitiveTypes::U32),
         }
     );
-    let state = block_state.borrow().get_context().clone().get();
+    let state = block_state.borrow().get_context().get();
     assert!(state.is_empty());
 }
 
@@ -945,7 +933,7 @@ fn expression_operation() {
             expr_value: ExpressionResultValue::Register(1),
         }
     );
-    let state = block_state.borrow().get_context().clone().get();
+    let state = block_state.borrow().get_context().get();
     assert_eq!(state.len(), 1);
     assert_eq!(
         state[0],
@@ -984,7 +972,7 @@ fn expression_operation_wrong_type() {
         t.state.errors[0]
     );
     assert!(res.is_none());
-    let state = block_state.borrow().get_context().clone().get();
+    let state = block_state.borrow().get_context().get();
     assert!(state.is_empty());
 }
 
@@ -1029,7 +1017,7 @@ fn expression_multiple_operation1() {
     let res = t.state.expression(&expr, &block_state).unwrap();
     assert_eq!(res.expr_type, Type::Primitive(PrimitiveTypes::U16));
     assert_eq!(res.expr_value, ExpressionResultValue::Register(5));
-    let state = block_state.borrow().get_context().clone().get();
+    let state = block_state.borrow().get_context().get();
     assert_eq!(state.len(), 5);
     assert_eq!(
         state[0],
@@ -1104,7 +1092,7 @@ fn expression_multiple_operation2() {
     let res = t.state.expression(&expr, &block_state).unwrap();
     assert_eq!(res.expr_type, Type::Primitive(PrimitiveTypes::U16));
     assert_eq!(res.expr_value, ExpressionResultValue::Register(5));
-    let state = block_state.borrow().get_context().clone().get();
+    let state = block_state.borrow().get_context().get();
     assert_eq!(state.len(), 5);
     assert_eq!(
         state[0],
@@ -1152,7 +1140,7 @@ fn expression_multiple_operation_simple1() {
     let res = t.state.expression(&expr, &block_state).unwrap();
     assert_eq!(res.expr_type, Type::Primitive(PrimitiveTypes::U16));
     assert_eq!(res.expr_value, ExpressionResultValue::Register(2));
-    let state = block_state.borrow().get_context().clone().get();
+    let state = block_state.borrow().get_context().get();
     assert_eq!(state.len(), 2);
     assert_eq!(
         state[0],
@@ -1185,7 +1173,7 @@ fn expression_multiple_operation_simple2() {
     let res = t.state.expression(&expr, &block_state).unwrap();
     assert_eq!(res.expr_type, Type::Primitive(PrimitiveTypes::U16));
     assert_eq!(res.expr_value, ExpressionResultValue::Register(2));
-    let state = block_state.borrow().get_context().clone().get();
+    let state = block_state.borrow().get_context().get();
     assert_eq!(state.len(), 2);
     assert_eq!(
         state[0],
@@ -1222,7 +1210,7 @@ fn expression_multiple_operation_simple3() {
     let res = t.state.expression(&expr, &block_state).unwrap();
     assert_eq!(res.expr_type, Type::Primitive(PrimitiveTypes::U16));
     assert_eq!(res.expr_value, ExpressionResultValue::Register(3));
-    let state = block_state.borrow().get_context().clone().get();
+    let state = block_state.borrow().get_context().get();
     assert_eq!(state.len(), 3);
     assert_eq!(
         state[0],
@@ -1267,7 +1255,7 @@ fn expression_multiple_operation_simple4() {
     let res = t.state.expression(&expr, &block_state).unwrap();
     assert_eq!(res.expr_type, Type::Primitive(PrimitiveTypes::U16));
     assert_eq!(res.expr_value, ExpressionResultValue::Register(3));
-    let state = block_state.borrow().get_context().clone().get();
+    let state = block_state.borrow().get_context().get();
     assert_eq!(state.len(), 3);
     assert_eq!(
         state[0],
@@ -1289,13 +1277,13 @@ fn custom_expression() {
     use semantic_analyzer::semantic::State;
     use semantic_analyzer::types::semantic::{ExtendedExpression, SemanticContextInstruction};
 
-    #[derive(Clone, Debug, PartialEq)]
+    #[derive(Clone, Debug, PartialEq, Eq)]
     pub enum AstCustomExpression {
         GoIn(u32, u32),
         GoOut(u32),
     }
 
-    #[derive(Clone, Debug, PartialEq)]
+    #[derive(Clone, Debug, PartialEq, Eq)]
     pub struct CustomExpression<I: SemanticContextInstruction> {
         ast: AstCustomExpression,
         _marker: PhantomData<I>,
@@ -1310,7 +1298,7 @@ fn custom_expression() {
         }
     }
 
-    #[derive(Clone, Debug, PartialEq)]
+    #[derive(Clone, Debug, PartialEq, Eq)]
     #[cfg_attr(feature = "codec", derive(serde::Serialize, serde::Deserialize))]
     pub enum CustomExpressionInstruction {
         GoIn { index: u32, value: u32 },
@@ -1369,7 +1357,7 @@ fn custom_expression() {
 
     let expr_into: Expression = expr.clone().into();
     // For grcov
-    let _ = format!("{:#?}", expr_into);
+    let _ = format!("{expr_into:#?}");
     // For grcov
     let _ = format!("{:#?}", expr_into.to_string());
     let res = state.expression(&expr, &block_state).unwrap();
@@ -1382,7 +1370,7 @@ fn custom_expression() {
             expr_value: ExpressionResultValue::Register(3),
         }
     );
-    let bs = block_state.borrow().get_context().clone().get();
+    let bs = block_state.borrow().get_context().get();
     assert_eq!(bs.len(), 3);
 
     assert_eq!(

--- a/tests/function_call_tests.rs
+++ b/tests/function_call_tests.rs
@@ -60,7 +60,7 @@ fn func_call_not_declared_func() {
     assert!(res.is_none());
     assert!(t.check_errors_len(1), "Errors: {:?}", t.state.errors.len());
     assert!(
-        t.check_error(StateErrorKind::FunctionNotFound),
+        t.check_error(&StateErrorKind::FunctionNotFound),
         "Errors: {:?}",
         t.state.errors[0]
     );
@@ -96,7 +96,7 @@ fn func_call_wrong_type() {
     assert_eq!(res, Type::Primitive(PrimitiveTypes::I16));
     assert!(t.check_errors_len(1), "Errors: {:?}", t.state.errors.len());
     assert!(
-        t.check_error(StateErrorKind::FunctionParameterTypeWrong),
+        t.check_error(&StateErrorKind::FunctionParameterTypeWrong),
         "Errors: {:?}",
         t.state.errors[0]
     );

--- a/tests/function_call_tests.rs
+++ b/tests/function_call_tests.rs
@@ -1,10 +1,10 @@
 use crate::utils::{CustomExpression, CustomExpressionInstruction, SemanticTest};
 use semantic_analyzer::ast;
 use semantic_analyzer::ast::{CodeLocation, GetLocation, GetName, Ident};
+use semantic_analyzer::types::FunctionCall;
 use semantic_analyzer::types::block_state::BlockState;
 use semantic_analyzer::types::error::StateErrorKind;
 use semantic_analyzer::types::types::{PrimitiveTypes, Type};
-use semantic_analyzer::types::FunctionCall;
 use std::cell::RefCell;
 use std::rc::Rc;
 

--- a/tests/function_declaration_tests.rs
+++ b/tests/function_declaration_tests.rs
@@ -37,7 +37,7 @@ fn function_declaration_without_body() {
     t.state.function_declaration(&fn_statement);
     assert!(t.check_errors_len(1), "Errors: {:?}", t.state.errors.len());
     assert!(
-        t.check_error(StateErrorKind::FunctionAlreadyExist),
+        t.check_error(&StateErrorKind::FunctionAlreadyExist),
         "Errors: {:?}",
         t.state.errors[0]
     );
@@ -65,7 +65,7 @@ fn function_declaration_wrong_type() {
     t.state.function_declaration(&fn_statement);
     assert!(t.check_errors_len(1), "Errors: {:?}", t.state.errors.len());
     assert!(
-        t.check_error(StateErrorKind::TypeNotFound),
+        t.check_error(&StateErrorKind::TypeNotFound),
         "Errors: {:?}",
         t.state.errors[0]
     );
@@ -90,7 +90,7 @@ fn function_declaration_wrong_type() {
     );
     t.state.function_declaration(&fn_statement2);
     assert!(t.check_errors_len(2), "Errors: {:?}", t.state.errors.len());
-    assert!(t.check_error_index(1, StateErrorKind::TypeNotFound));
+    assert!(t.check_error_index(1, &StateErrorKind::TypeNotFound));
     t.clean_errors();
 
     t.state.types(&type_decl);

--- a/tests/function_declaration_tests.rs
+++ b/tests/function_declaration_tests.rs
@@ -70,11 +70,12 @@ fn function_declaration_wrong_type() {
         t.state.errors[0]
     );
 
-    assert!(!t
-        .state
-        .global
-        .functions
-        .contains_key(&fn_name.clone().into()));
+    assert!(
+        !t.state
+            .global
+            .functions
+            .contains_key(&fn_name.clone().into())
+    );
     let state = t.state.global.context.clone().get();
     assert_eq!(state.len(), 0);
 

--- a/tests/if_tests.rs
+++ b/tests/if_tests.rs
@@ -181,8 +181,8 @@ fn if_logic_transform() {
         right: if_condition_expr.clone(),
     };
     let expr_cond6_into: ExpressionCondition = expr_cond6.into();
-    assert_eq!(expr_cond6_into.left, if_condition_expr_into.clone());
-    assert_eq!(expr_cond6_into.right, if_condition_expr_into.clone());
+    assert_eq!(expr_cond6_into.left, if_condition_expr_into);
+    assert_eq!(expr_cond6_into.right, if_condition_expr_into);
     assert_eq!(expr_cond6_into.condition, Condition::NotEq);
 
     let logic_cond_and = ast::LogicCondition::And;
@@ -370,7 +370,7 @@ fn if_condition_calculation_simple() {
         true,
     );
 
-    let ctx = block_state.borrow().get_context().clone().get();
+    let ctx = block_state.borrow().get_context().get();
     assert_eq!(ctx.len(), 2);
     assert_eq!(
         ctx[0],
@@ -483,7 +483,7 @@ fn if_condition_calculation_logic() {
         false,
     );
 
-    let ctx = block_state.borrow().get_context().clone().get();
+    let ctx = block_state.borrow().get_context().get();
     assert_eq!(
         ctx[0],
         SemanticStackContext::ConditionExpression {
@@ -785,7 +785,7 @@ fn else_if_statement() {
     println!("{:#?}", t.state.errors);
     assert!(t.is_empty_error());
 
-    let main_ctx = block_state.borrow().get_context().clone().get();
+    let main_ctx = block_state.borrow().get_context().get();
     assert_eq!(main_ctx.len(), 10);
     assert!(block_state.borrow().parent.is_none());
     assert_eq!(block_state.borrow().children.len(), 3);
@@ -802,7 +802,7 @@ fn else_if_statement() {
     assert!(ch_ctx3.borrow().parent.is_some());
     assert!(ch_ctx3.borrow().children.is_empty());
 
-    let ctx1 = ch_ctx1.borrow().get_context().clone().get();
+    let ctx1 = ch_ctx1.borrow().get_context().get();
     assert_eq!(ctx1.len(), 5);
     assert_eq!(
         ctx1[0],
@@ -848,7 +848,7 @@ fn else_if_statement() {
     );
     assert_eq!(ctx1[4], main_ctx[9]);
 
-    let ctx2 = ch_ctx2.borrow().get_context().clone().get();
+    let ctx2 = ch_ctx2.borrow().get_context().get();
     assert_eq!(ctx2.len(), 4);
     assert_eq!(
         ctx2[0],
@@ -887,7 +887,7 @@ fn else_if_statement() {
     );
     assert_eq!(ctx2[3], main_ctx[7]);
 
-    let ctx3 = ch_ctx3.borrow().get_context().clone().get();
+    let ctx3 = ch_ctx3.borrow().get_context().get();
     assert_eq!(ctx3.len(), 1);
     assert_eq!(
         ctx3[0],
@@ -1006,7 +1006,7 @@ fn if_body_statements() {
     assert!(ch_ctx1.borrow().parent.is_some());
     assert!(ch_ctx1.borrow().children.is_empty());
 
-    let ctx1 = ch_ctx1.borrow().get_context().clone().get();
+    let ctx1 = ch_ctx1.borrow().get_context().get();
     assert_eq!(ctx1.len(), 4);
     assert_eq!(
         ctx1[0],
@@ -1048,7 +1048,7 @@ fn if_body_statements() {
     assert!(ch_ctx2.borrow().parent.is_some());
     assert!(ch_ctx2.borrow().children.is_empty());
 
-    let ctx2 = ch_ctx2.borrow().get_context().clone().get();
+    let ctx2 = ch_ctx2.borrow().get_context().get();
     assert_eq!(ctx2.len(), 5);
     assert_eq!(
         ctx2[0],
@@ -1088,7 +1088,7 @@ fn if_body_statements() {
         }
     );
 
-    let stm_ctx = ctx.borrow().get_context().clone().get();
+    let stm_ctx = ctx.borrow().get_context().get();
     assert_eq!(stm_ctx.len(), 16);
     assert_eq!(stm_ctx, main_ctx);
     assert_eq!(
@@ -1280,7 +1280,7 @@ fn if_loop_body_statements() {
     );
     assert!(t.is_empty_error());
 
-    let main_ctx = block_state.borrow().get_context().clone().get();
+    let main_ctx = block_state.borrow().get_context().get();
     assert_eq!(main_ctx.len(), 16);
     assert!(block_state.borrow().parent.is_none());
     assert!(block_state.borrow().parent.is_none());
@@ -1294,7 +1294,7 @@ fn if_loop_body_statements() {
     assert!(ch_ctx1.borrow().parent.is_some());
     assert!(ch_ctx1.borrow().children.is_empty());
 
-    let ctx1 = ch_ctx1.borrow().get_context().clone().get();
+    let ctx1 = ch_ctx1.borrow().get_context().get();
     assert_eq!(ctx1.len(), 4);
     assert_eq!(
         ctx1[0],
@@ -1336,7 +1336,7 @@ fn if_loop_body_statements() {
     assert!(ch_ctx2.borrow().parent.is_some());
     assert!(ch_ctx2.borrow().children.is_empty());
 
-    let ctx2 = ch_ctx2.borrow().get_context().clone().get();
+    let ctx2 = ch_ctx2.borrow().get_context().get();
     assert_eq!(ctx2.len(), 5);
     assert_eq!(
         ctx2[0],
@@ -1375,7 +1375,7 @@ fn if_loop_body_statements() {
         }
     );
 
-    let stm_ctx = ctx.borrow().get_context().clone().get();
+    let stm_ctx = ctx.borrow().get_context().get();
     assert_eq!(stm_ctx.len(), 16);
     assert_eq!(stm_ctx, main_ctx);
     assert_eq!(

--- a/tests/if_tests.rs
+++ b/tests/if_tests.rs
@@ -107,7 +107,7 @@ fn if_single_transform() {
     let if_compare1 = *if_statement1_into.clone().else_if_statement.unwrap();
     let if_compare2 = IfStatement {
         else_if_statement: None,
-        ..if_statement1_into.clone()
+        ..if_statement1_into
     };
     assert_eq!(if_compare1, if_compare2);
     assert_eq!(if_statement1.location(), CodeLocation::new(1, 0));
@@ -131,8 +131,8 @@ fn if_logic_transform() {
         right: if_condition_expr.clone(),
     };
     let expr_cond1_into: ExpressionCondition = expr_cond1.into();
-    assert_eq!(expr_cond1_into.left, if_condition_expr_into.clone());
-    assert_eq!(expr_cond1_into.right, if_condition_expr_into.clone());
+    assert_eq!(expr_cond1_into.left, if_condition_expr_into);
+    assert_eq!(expr_cond1_into.right, if_condition_expr_into);
     assert_eq!(expr_cond1_into.condition, Condition::Great);
 
     let expr_cond2 = ast::ExpressionCondition {
@@ -141,8 +141,8 @@ fn if_logic_transform() {
         right: if_condition_expr.clone(),
     };
     let expr_cond2_into: ExpressionCondition = expr_cond2.into();
-    assert_eq!(expr_cond2_into.left, if_condition_expr_into.clone());
-    assert_eq!(expr_cond2_into.right, if_condition_expr_into.clone());
+    assert_eq!(expr_cond2_into.left, if_condition_expr_into);
+    assert_eq!(expr_cond2_into.right, if_condition_expr_into);
     assert_eq!(expr_cond2_into.condition, Condition::Less);
 
     let expr_cond3 = ast::ExpressionCondition {
@@ -151,8 +151,8 @@ fn if_logic_transform() {
         right: if_condition_expr.clone(),
     };
     let expr_cond3_into: ExpressionCondition = expr_cond3.into();
-    assert_eq!(expr_cond3_into.left, if_condition_expr_into.clone());
-    assert_eq!(expr_cond3_into.right, if_condition_expr_into.clone());
+    assert_eq!(expr_cond3_into.left, if_condition_expr_into);
+    assert_eq!(expr_cond3_into.right, if_condition_expr_into);
     assert_eq!(expr_cond3_into.condition, Condition::Eq);
 
     let expr_cond4 = ast::ExpressionCondition {
@@ -161,8 +161,8 @@ fn if_logic_transform() {
         right: if_condition_expr.clone(),
     };
     let expr_cond4_into: ExpressionCondition = expr_cond4.into();
-    assert_eq!(expr_cond4_into.left, if_condition_expr_into.clone());
-    assert_eq!(expr_cond4_into.right, if_condition_expr_into.clone());
+    assert_eq!(expr_cond4_into.left, if_condition_expr_into);
+    assert_eq!(expr_cond4_into.right, if_condition_expr_into);
     assert_eq!(expr_cond4_into.condition, Condition::GreatEq);
 
     let expr_cond5 = ast::ExpressionCondition {
@@ -171,8 +171,8 @@ fn if_logic_transform() {
         right: if_condition_expr.clone(),
     };
     let expr_cond5_into: ExpressionCondition = expr_cond5.into();
-    assert_eq!(expr_cond5_into.left, if_condition_expr_into.clone());
-    assert_eq!(expr_cond5_into.right, if_condition_expr_into.clone());
+    assert_eq!(expr_cond5_into.left, if_condition_expr_into);
+    assert_eq!(expr_cond5_into.right, if_condition_expr_into);
     assert_eq!(expr_cond5_into.condition, Condition::LessEq);
 
     let expr_cond6 = ast::ExpressionCondition {
@@ -314,7 +314,7 @@ fn check_if_and_else_if_statement_duplicate() {
     t.state.if_condition(&if_stmt, &block_state, &None, None);
     assert!(t.check_errors_len(1), "Errors: {:?}", t.state.errors.len());
     assert!(
-        t.check_error(StateErrorKind::IfElseDuplicated),
+        t.check_error(&StateErrorKind::IfElseDuplicated),
         "Errors: {:?}",
         t.state.errors[0]
     );
@@ -396,7 +396,7 @@ fn if_condition_calculation_simple() {
     );
     assert!(t.check_errors_len(1), "Errors: {:?}", t.state.errors.len());
     assert!(
-        t.check_error(StateErrorKind::ValueNotFound),
+        t.check_error(&StateErrorKind::ValueNotFound),
         "Errors: {:?}",
         t.state.errors[0]
     );
@@ -620,12 +620,12 @@ fn if_condition_when_left_expr_return_error() {
     );
     assert!(t.check_errors_len(2), "Errors: {:?}", t.state.errors.len());
     assert!(
-        t.check_error_index(0, StateErrorKind::FunctionNotFound),
+        t.check_error_index(0, &StateErrorKind::FunctionNotFound),
         "Errors: {:?}",
         t.state.errors[0]
     );
     assert!(
-        t.check_error_index(1, StateErrorKind::ConditionIsEmpty),
+        t.check_error_index(1, &StateErrorKind::ConditionIsEmpty),
         "Errors: {:?}",
         t.state.errors[1]
     );
@@ -667,7 +667,7 @@ fn if_condition_left_expr_and_right_expr_different_type() {
     );
     assert!(t.check_errors_len(1), "Errors: {:?}", t.state.errors.len());
     assert!(
-        t.check_error(StateErrorKind::ConditionExpressionWrongType),
+        t.check_error(&StateErrorKind::ConditionExpressionWrongType),
         "Errors: {:?}",
         t.state.errors[0]
     );
@@ -730,7 +730,7 @@ fn if_condition_primitive_type_only_check() {
     );
     assert!(t.check_errors_len(1), "Errors: {:?}", t.state.errors.len());
     assert!(
-        t.check_error(StateErrorKind::ConditionExpressionNotSupported),
+        t.check_error(&StateErrorKind::ConditionExpressionNotSupported),
         "Errors: {:?}",
         t.state.errors[0]
     );
@@ -1508,7 +1508,7 @@ fn if_loop_body_instructions_after_return() {
 
     assert!(t.check_errors_len(1), "Errors: {:?}", t.state.errors.len());
     assert!(
-        t.check_error(StateErrorKind::ForbiddenCodeAfterReturnDeprecated),
+        t.check_error(&StateErrorKind::ForbiddenCodeAfterReturnDeprecated),
         "Errors: {:?}",
         t.state.errors[0]
     );
@@ -1560,7 +1560,7 @@ fn else_if_loop_body_instructions_after_return() {
 
     assert!(t.check_errors_len(1), "Errors: {:?}", t.state.errors.len());
     assert!(
-        t.check_error(StateErrorKind::ForbiddenCodeAfterReturnDeprecated),
+        t.check_error(&StateErrorKind::ForbiddenCodeAfterReturnDeprecated),
         "Errors: {:?}",
         t.state.errors[0]
     );
@@ -1609,7 +1609,7 @@ fn if_body_instructions_after_return() {
 
     assert!(t.check_errors_len(1), "Errors: {:?}", t.state.errors.len());
     assert!(
-        t.check_error(StateErrorKind::ForbiddenCodeAfterReturnDeprecated),
+        t.check_error(&StateErrorKind::ForbiddenCodeAfterReturnDeprecated),
         "Errors: {:?}",
         t.state.errors[0]
     );
@@ -1661,7 +1661,7 @@ fn if_else_body_instructions_after_return() {
 
     assert!(t.check_errors_len(1), "Errors: {:?}", t.state.errors.len());
     assert!(
-        t.check_error(StateErrorKind::ForbiddenCodeAfterReturnDeprecated),
+        t.check_error(&StateErrorKind::ForbiddenCodeAfterReturnDeprecated),
         "Errors: {:?}",
         t.state.errors[0]
     );
@@ -1706,7 +1706,7 @@ fn if_loop_body_instructions_after_break() {
     );
     assert!(t.check_errors_len(1), "Errors: {:?}", t.state.errors.len());
     assert!(
-        t.check_error(StateErrorKind::ForbiddenCodeAfterBreakDeprecated),
+        t.check_error(&StateErrorKind::ForbiddenCodeAfterBreakDeprecated),
         "Errors: {:?}",
         t.state.errors[0]
     );
@@ -1751,7 +1751,7 @@ fn if_loop_body_instructions_after_continue() {
     );
     assert!(t.check_errors_len(1), "Errors: {:?}", t.state.errors.len());
     assert!(
-        t.check_error(StateErrorKind::ForbiddenCodeAfterContinueDeprecated),
+        t.check_error(&StateErrorKind::ForbiddenCodeAfterContinueDeprecated),
         "Errors: {:?}",
         t.state.errors[0]
     );

--- a/tests/let_binding_tests.rs
+++ b/tests/let_binding_tests.rs
@@ -176,10 +176,12 @@ fn let_binding_value_found() {
             },
         }
     );
-    assert!(block_state
-        .borrow()
-        .inner_values_name
-        .contains(&val2.inner_name));
+    assert!(
+        block_state
+            .borrow()
+            .inner_values_name
+            .contains(&val2.inner_name)
+    );
     assert_eq!(
         block_state.borrow().values.get(&("x".into())).unwrap(),
         &val2

--- a/tests/let_binding_tests.rs
+++ b/tests/let_binding_tests.rs
@@ -31,7 +31,7 @@ fn let_binding_transform() {
     assert_eq!(let_binding_ast.clone().name(), "x");
 
     let let_binding: LetBinding = let_binding_ast.clone().into();
-    assert_eq!(let_binding.clone().to_string(), "x");
+    assert_eq!(let_binding.to_string(), "x");
     assert!(let_binding.mutable);
     assert_eq!(
         let_binding.value_type,
@@ -59,7 +59,7 @@ fn let_binding_wrong_expression() {
     t.state.let_binding(&let_binding, &block_state);
     assert!(t.check_errors_len(1), "Errors: {:?}", t.state.errors.len());
     assert!(
-        t.check_error(StateErrorKind::ValueNotFound),
+        t.check_error(&StateErrorKind::ValueNotFound),
         "Errors: {:?}",
         t.state.errors[0]
     );
@@ -82,7 +82,7 @@ fn let_binding_wrong_type() {
     t.state.let_binding(&let_binding, &block_state);
     assert!(t.check_errors_len(1), "Errors: {:?}", t.state.errors.len());
     assert!(
-        t.check_error(StateErrorKind::WrongLetType),
+        t.check_error(&StateErrorKind::WrongLetType),
         "Errors: {:?}",
         t.state.errors[0]
     );
@@ -104,7 +104,7 @@ fn let_binding_value_not_found() {
     };
     t.state.let_binding(&let_binding, &block_state);
     assert!(t.is_empty_error());
-    let state = block_state.borrow().get_context().clone().get();
+    let state = block_state.borrow().get_context().get();
     assert_eq!(state.len(), 1);
     let inner_name: InnerValueName = "x.0".into();
     let val = Value {
@@ -141,7 +141,7 @@ fn let_binding_value_found() {
     };
     let inner_name: InnerValueName = "x.0".into();
     let val = Value {
-        inner_name: inner_name.clone(),
+        inner_name,
         inner_type: Type::Primitive(PrimitiveTypes::U64),
         mutable: true,
         alloca: false,
@@ -159,12 +159,12 @@ fn let_binding_value_found() {
     };
     t.state.let_binding(&let_binding, &block_state);
     assert!(t.is_empty_error());
-    let state = block_state.borrow().get_context().clone().get();
+    let state = block_state.borrow().get_context().get();
     assert_eq!(state.len(), 1);
 
     let val2 = Value {
         inner_name: "x.1".into(),
-        ..val.clone()
+        ..val
     };
     assert_eq!(
         state[0],

--- a/tests/loop_tests.rs
+++ b/tests/loop_tests.rs
@@ -178,7 +178,7 @@ fn loop_statements() {
     assert!(ch_ctx1.borrow().parent.is_some());
     assert!(ch_ctx1.borrow().children.is_empty());
 
-    let ctx1 = ch_ctx1.borrow().get_context().clone().get();
+    let ctx1 = ch_ctx1.borrow().get_context().get();
     assert_eq!(ctx1.len(), 5);
     assert_eq!(
         ctx1[0],
@@ -226,7 +226,7 @@ fn loop_statements() {
     assert!(ch_ctx2.borrow().parent.is_some());
     assert!(ch_ctx2.borrow().children.is_empty());
 
-    let ctx2 = ch_ctx2.borrow().get_context().clone().get();
+    let ctx2 = ch_ctx2.borrow().get_context().get();
     assert_eq!(ctx2.len(), 5);
     assert_eq!(
         ctx2[0],
@@ -265,7 +265,7 @@ fn loop_statements() {
         }
     );
 
-    let stm_ctx = ctx.borrow().get_context().clone().get();
+    let stm_ctx = ctx.borrow().get_context().get();
     assert_eq!(stm_ctx.len(), 17);
     assert_eq!(stm_ctx, main_ctx);
     assert_eq!(
@@ -373,7 +373,7 @@ fn loop_statements_instructions_after_return() {
     t.state.loop_statement(&loop_stmt, &block_state);
     assert!(t.check_errors_len(1), "Errors: {:?}", t.state.errors.len());
     assert!(
-        t.check_error(StateErrorKind::ForbiddenCodeAfterReturnDeprecated),
+        t.check_error(&StateErrorKind::ForbiddenCodeAfterReturnDeprecated),
         "Errors: {:?}",
         t.state.errors[0]
     );
@@ -401,7 +401,7 @@ fn loop_statements_instructions_after_break() {
     t.state.loop_statement(&loop_stmt, &block_state);
     assert!(t.check_errors_len(1), "Errors: {:?}", t.state.errors.len());
     assert!(
-        t.check_error(StateErrorKind::ForbiddenCodeAfterBreakDeprecated),
+        t.check_error(&StateErrorKind::ForbiddenCodeAfterBreakDeprecated),
         "Errors: {:?}",
         t.state.errors[0]
     );
@@ -429,7 +429,7 @@ fn loop_statements_instructions_after_continue() {
     t.state.loop_statement(&loop_stmt, &block_state);
     assert!(t.check_errors_len(1), "Errors: {:?}", t.state.errors.len());
     assert!(
-        t.check_error(StateErrorKind::ForbiddenCodeAfterContinueDeprecated),
+        t.check_error(&StateErrorKind::ForbiddenCodeAfterContinueDeprecated),
         "Errors: {:?}",
         t.state.errors[0]
     );
@@ -469,7 +469,7 @@ fn loop_statements_with_return_invocation() {
     assert!(ctx.borrow().parent.is_some());
     assert!(ctx.borrow().children.is_empty());
 
-    let stm_ctx = ctx.borrow().get_context().clone().get();
+    let stm_ctx = ctx.borrow().get_context().get();
     assert_eq!(stm_ctx.len(), 4);
     assert_eq!(stm_ctx, main_ctx);
     assert_eq!(

--- a/tests/main_tests.rs
+++ b/tests/main_tests.rs
@@ -3,10 +3,10 @@ use semantic_analyzer::ast::{self, GetName, Ident};
 use semantic_analyzer::types::error::StateErrorKind;
 use semantic_analyzer::types::expression::ExpressionOperations;
 use semantic_analyzer::types::{
+    Function, PrimitiveValue, Value,
     expression::{ExpressionResult, ExpressionResultValue},
     semantic::SemanticStackContext,
     types::{PrimitiveTypes, Type},
-    Function, PrimitiveValue, Value,
 };
 
 mod utils;

--- a/tests/main_tests.rs
+++ b/tests/main_tests.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::similar_names)]
 use crate::utils::{CustomExpression, CustomExpressionInstruction, SemanticTest};
 use semantic_analyzer::ast::{self, GetName, Ident};
 use semantic_analyzer::types::error::StateErrorKind;
@@ -154,7 +155,7 @@ fn main_run() {
     assert!(ch_ctx2.borrow().children.is_empty());
 
     // Semantic stack context for the block fn2
-    let st_ctx2 = ctx2.get_context().clone().get();
+    let st_ctx2 = ctx2.get_context().get();
     assert_eq!(st_ctx2.len(), 1);
     assert_eq!(
         st_ctx2[0],
@@ -166,7 +167,7 @@ fn main_run() {
         }
     );
 
-    let st_ch_ctx1 = ch_ctx1.borrow().get_context().clone().get();
+    let st_ch_ctx1 = ch_ctx1.borrow().get_context().get();
     assert_eq!(st_ch_ctx1.len(), 5);
     assert_eq!(
         st_ch_ctx1[0],
@@ -210,7 +211,7 @@ fn main_run() {
         }
     );
 
-    let st_ch_ctx2 = ch_ctx2.borrow().get_context().clone().get();
+    let st_ch_ctx2 = ch_ctx2.borrow().get_context().get();
     assert_eq!(st_ch_ctx2.len(), 5);
     assert_eq!(
         st_ch_ctx2[0],
@@ -278,7 +279,7 @@ fn main_run() {
     );
 
     // Semantic stack context for the block fn1
-    let st_ctx1 = ctx1.get_context().clone().get();
+    let st_ctx1 = ctx1.get_context().get();
     assert_eq!(st_ctx1.len(), 14);
     assert_eq!(
         st_ctx1[0],
@@ -369,8 +370,8 @@ fn double_return() {
     > = vec![fn_stm];
     t.state.run(&main_stm);
     assert!(t.check_errors_len(2), "Errors: {:?}", t.state.errors.len());
-    assert!(t.check_error_index(0, StateErrorKind::ForbiddenCodeAfterReturnDeprecated));
-    assert!(t.check_error_index(1, StateErrorKind::ReturnAlreadyCalled));
+    assert!(t.check_error_index(0, &StateErrorKind::ForbiddenCodeAfterReturnDeprecated));
+    assert!(t.check_error_index(1, &StateErrorKind::ReturnAlreadyCalled));
 }
 
 #[test]
@@ -394,7 +395,7 @@ fn wrong_return_type() {
     t.state.run(&main_stm);
     assert!(t.check_errors_len(1), "Errors: {:?}", t.state.errors.len());
     assert!(
-        t.check_error(StateErrorKind::WrongReturnType),
+        t.check_error(&StateErrorKind::WrongReturnType),
         "Errors: {:?}",
         t.state.errors[0]
     );
@@ -428,7 +429,7 @@ fn expression_as_return() {
     assert!(ctx.parent.is_none());
 
     // Semantic stack context for the block
-    let st_ctx = ctx.get_context().clone().get();
+    let st_ctx = ctx.get_context().get();
     assert_eq!(st_ctx.len(), 1);
     assert_eq!(
         st_ctx[0],
@@ -498,7 +499,7 @@ fn if_return_from_function() {
     assert!(children_ctx.parent.is_some());
 
     // Children semantic stack context for the block
-    let st_children_ctx = children_ctx.get_context().clone().get();
+    let st_children_ctx = children_ctx.get_context().get();
     assert_eq!(st_children_ctx.len(), 4);
     assert_eq!(
         st_children_ctx[0],
@@ -728,5 +729,5 @@ fn function_args_duplication() {
     > = vec![fn_stm];
     t.state.run(&main_stm);
     assert!(t.check_errors_len(1));
-    assert!(t.check_error(StateErrorKind::FunctionArgumentNameDuplicated));
+    assert!(t.check_error(&StateErrorKind::FunctionArgumentNameDuplicated));
 }

--- a/tests/state_tests.rs
+++ b/tests/state_tests.rs
@@ -217,7 +217,7 @@ fn block_state_value() {
         malloc: false,
     };
     bst1.borrow_mut().values.insert(vn1.clone(), val.clone());
-    assert_eq!(bst1.borrow().get_value_name(&vn1).unwrap(), val.clone());
+    assert_eq!(bst1.borrow().get_value_name(&vn1).unwrap(), val);
     assert_eq!(bst2.borrow().get_value_name(&vn1).unwrap(), val);
     assert!(bst3.borrow().get_value_name(&vn1).is_none());
 

--- a/tests/state_tests.rs
+++ b/tests/state_tests.rs
@@ -7,11 +7,11 @@ use semantic_analyzer::types::expression::{
 };
 use semantic_analyzer::types::semantic::{ExtendedSemanticContext, SemanticContext};
 use semantic_analyzer::types::{
+    Constant, ConstantExpression, ConstantValue, Function, FunctionParameter, InnerValueName,
+    LabelName, Value, ValueName,
     block_state::BlockState,
     semantic::SemanticStack,
     types::{PrimitiveTypes, Type},
-    Constant, ConstantExpression, ConstantValue, Function, FunctionParameter, InnerValueName,
-    LabelName, Value, ValueName,
 };
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -142,9 +142,10 @@ fn block_state_inner_value_name() {
 
     let inner_value_name2_0 = "x2.0".into();
     bst2.borrow_mut().set_inner_value_name(&inner_value_name2_0);
-    assert!(bst2
-        .borrow()
-        .is_inner_value_name_exist(&inner_value_name2_0));
+    assert!(
+        bst2.borrow()
+            .is_inner_value_name_exist(&inner_value_name2_0)
+    );
     assert_eq!(
         bst1.borrow()
             .get_next_inner_name(&inner_value_name2)

--- a/tests/types_tests.rs
+++ b/tests/types_tests.rs
@@ -1,11 +1,11 @@
 use crate::utils::SemanticTest;
 use semantic_analyzer::ast::{self, GetLocation, GetName, Ident};
+use semantic_analyzer::types::ValueName;
 use semantic_analyzer::types::error::StateErrorKind;
 use semantic_analyzer::types::semantic::SemanticStackContext;
 use semantic_analyzer::types::types::{
     PrimitiveTypes, StructAttributeType, StructTypes, Type, TypeAttributes,
 };
-use semantic_analyzer::types::ValueName;
 
 mod utils;
 

--- a/tests/types_tests.rs
+++ b/tests/types_tests.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::similar_names)]
 use crate::utils::SemanticTest;
 use semantic_analyzer::ast::{self, GetLocation, GetName, Ident};
 use semantic_analyzer::types::ValueName;
@@ -335,7 +336,7 @@ fn types_declaration() {
     t.state.types(&type_decl2.clone());
     assert!(t.check_errors_len(1), "Errors: {:?}", t.state.errors.len());
     assert!(
-        t.check_error(StateErrorKind::TypeAlreadyExist),
+        t.check_error(&StateErrorKind::TypeAlreadyExist),
         "Errors: {:?}",
         t.state.errors[0]
     );

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -60,7 +60,7 @@ impl SemanticTest<CustomExpressionInstruction> {
 
     #[allow(dead_code)]
     pub fn clean_errors(&mut self) {
-        self.state.errors = vec![];
+        self.state.errors.clear();
     }
 
     #[allow(dead_code)]

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -54,7 +54,7 @@ impl SemanticTest<CustomExpressionInstruction> {
     }
 
     #[allow(dead_code)]
-    pub fn is_empty_error(&self) -> bool {
+    pub const fn is_empty_error(&self) -> bool {
         self.state.errors.is_empty()
     }
 
@@ -64,7 +64,7 @@ impl SemanticTest<CustomExpressionInstruction> {
     }
 
     #[allow(dead_code)]
-    pub fn check_errors_len(&self, len: usize) -> bool {
+    pub const fn check_errors_len(&self, len: usize) -> bool {
         self.state.errors.len() == len
     }
 

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -1,10 +1,10 @@
 use semantic_analyzer::semantic::State;
+use semantic_analyzer::types::PrimitiveValue;
 use semantic_analyzer::types::block_state::BlockState;
 use semantic_analyzer::types::error::StateErrorKind;
 use semantic_analyzer::types::expression::{ExpressionResult, ExpressionResultValue};
 use semantic_analyzer::types::semantic::{ExtendedExpression, SemanticContextInstruction};
 use semantic_analyzer::types::types::{PrimitiveTypes, Type};
-use semantic_analyzer::types::PrimitiveValue;
 #[cfg(feature = "codec")]
 use serde::{Deserialize, Serialize};
 use std::cell::RefCell;

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -11,7 +11,7 @@ use std::cell::RefCell;
 use std::marker::PhantomData;
 use std::rc::Rc;
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "codec", derive(Serialize, Deserialize))]
 pub struct CustomExpression<I: SemanticContextInstruction> {
     _marker: PhantomData<I>,
@@ -30,7 +30,7 @@ impl<I: SemanticContextInstruction> ExtendedExpression<I> for CustomExpression<I
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "codec", derive(Serialize, Deserialize))]
 pub struct CustomExpressionInstruction;
 
@@ -60,7 +60,7 @@ impl SemanticTest<CustomExpressionInstruction> {
 
     #[allow(dead_code)]
     pub fn clean_errors(&mut self) {
-        self.state.errors = vec![]
+        self.state.errors = vec![];
     }
 
     #[allow(dead_code)]
@@ -69,12 +69,12 @@ impl SemanticTest<CustomExpressionInstruction> {
     }
 
     #[allow(dead_code)]
-    pub fn check_error(&self, err_kind: StateErrorKind) -> bool {
-        self.state.errors.first().unwrap().kind == err_kind
+    pub fn check_error(&self, err_kind: &StateErrorKind) -> bool {
+        &self.state.errors.first().unwrap().kind == err_kind
     }
 
     #[allow(dead_code)]
-    pub fn check_error_index(&self, index: usize, err_kind: StateErrorKind) -> bool {
-        self.state.errors.get(index).unwrap().kind == err_kind
+    pub fn check_error_index(&self, index: usize, err_kind: &StateErrorKind) -> bool {
+        &self.state.errors.get(index).unwrap().kind == err_kind
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release v0.4.7

* **Chores**
  * Updated to Rust edition 2024 and set minimum Rust version to 1.88.0.
  * Updated linting configuration for stricter static checks.

* **Refactor**
  * Simplified recursive types and reduced unnecessary cloning across the codebase for cleaner internals.

* **Tests**
  * Updated test suite to match internal type/ownership changes and maintain test reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->